### PR TITLE
리팩터링: Monthly Garbage Collection Node.js 20 경고 정리

### DIFF
--- a/.github/workflows/monthly-garbage-collection.yml
+++ b/.github/workflows/monthly-garbage-collection.yml
@@ -33,7 +33,7 @@ jobs:
         run: make verify-all
 
       - name: Create Draft Cleanup PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: codex/monthly-gc
           commit-message: "Run monthly garbage collection"


### PR DESCRIPTION
## 요약
- `Monthly Garbage Collection` workflow의 `peter-evans/create-pull-request`를 `v8`으로 올렸습니다
- v8 계열은 공식 `action.yml` 기준 `runs.using: node24`라서 기존 Node.js 20 deprecation 경고 제거 목적에 맞습니다

## 검증
- `make verify-all`

Closes #13