### PR TITLE
CI: PR 체크 job 이름을 분리

### DIFF
--- a/.github/workflows/architecture-invariants.yml
+++ b/.github/workflows/architecture-invariants.yml
@@ -7,7 +7,8 @@ on:
       - main
 
 jobs:
-  verify:
+  architecture_invariants:
+    name: Architecture Invariants
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -7,7 +7,8 @@ on:
       - main
 
 jobs:
-  verify:
+  docs_verify:
+    name: Docs Verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/golden-principles.yml
+++ b/.github/workflows/golden-principles.yml
@@ -7,7 +7,8 @@ on:
       - main
 
 jobs:
-  verify:
+  golden_principles:
+    name: Golden Principles
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## 요약
- `Docs Verify`, `Architecture Invariants`, `Golden Principles` workflow의 job 이름을 각각 고유하게 분리했습니다
- top-level workflow `name`은 유지하고, `jobs`의 key/name만 명확하게 정리했습니다
- 실행 로직, 트리거, step은 변경하지 않았습니다

## 왜 필요한가
- 현재 PR 체크가 모두 `verify`로 표시되어 required status check 설정 시 식별이 모호합니다
- 각 체크를 GitHub ruleset에서 개별 required check로 지정할 수 있도록 이름을 안정화합니다

## 검증
- Ruby `YAML.load_file`로 세 workflow 파일 파싱 확인