### PR TITLE
리팩터링: architecture invariant를 WorkPulse 구조에 맞춘다

### DIFF
--- a/.architecture-invariants.toml
+++ b/.architecture-invariants.toml
@@ -120,5 +120,5 @@ message = "UserDefaults must stay behind a repo adapter or runtime composition r
 [[content_rules]]
 id = "direct-time-context-outside-runtime"
 layers = ["domain", "repo", "service", "ui"]
-pattern = "\\bDate\\(\\)|\\bCalendar\\.current\\b|\\bTimeZone\\.current\\b|\\bLocale\\.current\\b"
+pattern = "\\bDate\\(\\)|\\bDate\\.init\\b|\\bCalendar\\.current\\b|\\bTimeZone\\.current\\b|\\bLocale\\.current\\b"
 message = "Use injected date/calendar/timezone/locale dependencies instead of direct current context access."

--- a/UI/MainPopover/MainPopoverCurrentSessionBinder.swift
+++ b/UI/MainPopover/MainPopoverCurrentSessionBinder.swift
@@ -27,7 +27,7 @@ final class MainPopoverCurrentSessionBinder {
         copy: MainPopoverCopy = .english,
         progressPolicy: MainPopoverCurrentSessionProgressPolicy = MainPopoverCurrentSessionProgressPolicy(),
         currentSessionCalculator: CurrentSessionCalculator = CurrentSessionCalculator(),
-        currentTimeProvider: @escaping () -> Date = Date.init,
+        currentTimeProvider: @escaping () -> Date,
         currentSessionScheduler: any CurrentSessionScheduling = TimerCurrentSessionScheduler()
     ) {
         self.copy = copy

--- a/UI/MainPopover/MainPopoverCurrentSessionRuntime.swift
+++ b/UI/MainPopover/MainPopoverCurrentSessionRuntime.swift
@@ -11,7 +11,7 @@ final class MainPopoverCurrentSessionRuntime {
 
     init(
         currentSessionCalculator: CurrentSessionCalculator = CurrentSessionCalculator(),
-        currentTimeProvider: @escaping () -> Date = Date.init,
+        currentTimeProvider: @escaping () -> Date,
         currentSessionScheduler: any CurrentSessionScheduling = TimerCurrentSessionScheduler(),
         placeholderText: String = MainPopoverCopy.english.currentSessionPlaceholderText,
         onChange: @escaping (String, TimeInterval?) -> Void

--- a/UI/MainPopover/MainPopoverViewController.swift
+++ b/UI/MainPopover/MainPopoverViewController.swift
@@ -53,7 +53,7 @@ final class MainPopoverViewController: NSViewController {
         state: MainPopoverViewState,
         currentSessionCalculator: CurrentSessionCalculator = CurrentSessionCalculator(),
         copy: MainPopoverCopy = .english,
-        currentTimeProvider: @escaping () -> Date = Date.init,
+        currentTimeProvider: @escaping () -> Date,
         currentSessionScheduler: any CurrentSessionScheduling = TimerCurrentSessionScheduler()
     ) {
         self.state = state

--- a/WorkPulseTests/MainPopoverViewControllerTests.swift
+++ b/WorkPulseTests/MainPopoverViewControllerTests.swift
@@ -182,7 +182,7 @@ struct MainPopoverViewControllerTests {
     @MainActor
     private func makeController(
         state: MainPopoverViewState = MainPopoverViewStateFactory(copy: .english).makePlaceholder(),
-        currentTimeProvider: @escaping () -> Date = Date.init,
+        currentTimeProvider: @escaping () -> Date = { Date(timeIntervalSince1970: 0) },
         currentSessionScheduler: any CurrentSessionScheduling = TimerCurrentSessionScheduler(),
         currentSessionCalculator: CurrentSessionCalculator = makeSeoulCurrentSessionCalculator()
     ) -> MainPopoverViewController {


### PR DESCRIPTION
## Summary
- align `.architecture-invariants.toml` with the current WorkPulse source tree instead of the starter layout
- add AppKit ownership and forbidden-content rules for the macOS menu bar app structure
- add guardrails for direct `UserDefaults` usage and direct current time/context access outside the allowed layers

## Verification
- make verify-architecture