### PR TITLE
테스트: 현재 세션과 프로그레스 동기화를 고정

### DIFF
--- a/WorkPulseTests/CurrentSessionCalculatorTests.swift
+++ b/WorkPulseTests/CurrentSessionCalculatorTests.swift
@@ -643,6 +643,7 @@ struct AppDelegateTests {
         #expect(persistedTodayRecord.endTime == endTime)
         #expect(snapshot.todayTimes.endRow.valueText == "18:30")
         #expect(snapshot.currentSession.valueText == "08:30:00")
+        #expect(abs(snapshot.currentSession.progressFraction - 0.94) < 0.001)
         #expect(snapshot.summary.weeklyValueText == "15:30")
         #expect(snapshot.summary.monthlyValueText == "15:30")
     }


### PR DESCRIPTION
## 요약
- 퇴근 시간 수정 직후 `Current Session` 텍스트와 progress bar가 같은 상태에서 갱신되는지 회귀 테스트를 추가했습니다.
- 현재 `main` 구조에서는 해당 동기화 경로가 이미 맞게 동작하고 있어 제품 코드 변경은 하지 않았습니다.

## 검증
- `xcodebuild -project WorkPulse.xcodeproj -scheme WorkPulse -destination 'platform=macOS' -derivedDataPath /tmp/WorkPulseDD15 -only-testing:WorkPulseTests/AppDelegateTests test`
- `make verify`

Closes #23