### PR TITLE
[codex] 기능: 잘못 입력한 퇴근 시간을 삭제할 수 있게 한다

### DIFF
--- a/Feature/MainPopover/Presentation/MainPopoverCopy.swift
+++ b/Feature/MainPopover/Presentation/MainPopoverCopy.swift
@@ -10,6 +10,7 @@ struct MainPopoverCopy {
     let currentSessionLeadingCaption: String
     let startTimeTitle: String
     let endTimeTitle: String
+    let deleteActionTitle: String
     let weeklyTitle: String
     let monthlyTitle: String
     let currentSessionGoalLabelPrefix: String
@@ -24,6 +25,7 @@ struct MainPopoverCopy {
         currentSessionLeadingCaption: "0H",
         startTimeTitle: "Start Time",
         endTimeTitle: "End Time",
+        deleteActionTitle: "Delete",
         weeklyTitle: "This Week",
         monthlyTitle: "This Month",
         currentSessionGoalLabelPrefix: "Goal:"

--- a/Feature/MainPopover/Presentation/MainPopoverRenderModelFactory.swift
+++ b/Feature/MainPopover/Presentation/MainPopoverRenderModelFactory.swift
@@ -28,6 +28,7 @@ struct MainPopoverTodayTimesRenderModel {
     let showsEditingActions: Bool
     let showsStartActions: Bool
     let showsEndActions: Bool
+    let showsEndDeleteAction: Bool
     let isApplyEnabled: Bool
 }
 

--- a/Feature/MainPopover/Presentation/TodayTimeEditModeState.swift
+++ b/Feature/MainPopover/Presentation/TodayTimeEditModeState.swift
@@ -57,6 +57,16 @@ struct TodayTimeEditModeState {
         return (savedStartTime, savedEndTime)
     }
 
+    mutating func deleteEndTime() -> (startTime: Date?, endTime: Date?)? {
+        guard editingField == .endTime else { return nil }
+
+        savedEndTime = nil
+        draftEndTime = nil
+        editingField = nil
+
+        return (savedStartTime, nil)
+    }
+
     mutating func cancel() {
         draftStartTime = savedStartTime
         draftEndTime = savedEndTime

--- a/UI/MainPopover/MainPopoverTodayTimesBinder.swift
+++ b/UI/MainPopover/MainPopoverTodayTimesBinder.swift
@@ -20,6 +20,7 @@ final class MainPopoverTodayTimesBinder {
     ) {
         self.sectionView = sectionView
         self.copy = copy
+        sectionView.setDeleteActionTitle(copy.deleteActionTitle)
         bindSectionEvents()
     }
 
@@ -64,6 +65,18 @@ final class MainPopoverTodayTimesBinder {
         onDidChange?()
     }
 
+    func deleteEndTime() {
+        guard let appliedTimes = editModeState.deleteEndTime() else { return }
+
+        onDidApplyTimes?(
+            MainPopoverAppliedTodayTimes(
+                startTime: appliedTimes.startTime,
+                endTime: appliedTimes.endTime
+            )
+        )
+        onDidChange?()
+    }
+
     func setEditingDraft(_ draft: MainPopoverTodayTimesDraft) {
         sectionView.setEditingDraft(draft)
     }
@@ -90,6 +103,7 @@ final class MainPopoverTodayTimesBinder {
             showsEditingActions: editModeState.editingField != nil,
             showsStartActions: editModeState.isEditingStartTime,
             showsEndActions: editModeState.isEditingEndTime,
+            showsEndDeleteAction: editModeState.isEditingEndTime && editModeState.savedEndTime != nil,
             isApplyEnabled: editModeState.hasValidDraftTimes
         )
     }
@@ -103,6 +117,8 @@ final class MainPopoverTodayTimesBinder {
                 self?.applyEditing()
             case .cancelEditing:
                 self?.cancelEditing()
+            case .deleteEndTime:
+                self?.deleteEndTime()
             case .draftChanged(let draft):
                 self?.updateDraft(draft)
             }

--- a/UI/MainPopover/MainPopoverTodayTimesSectionView.swift
+++ b/UI/MainPopover/MainPopoverTodayTimesSectionView.swift
@@ -178,6 +178,7 @@ struct MainPopoverTodayTimesSectionSnapshot {
     let isStartCancelVisible: Bool
     let isEndApplyVisible: Bool
     let isEndCancelVisible: Bool
+    let isEndDeleteVisible: Bool
     let isApplyEnabled: Bool
     let isBackgroundFullWidth: Bool
     let areEditingActionsOutsideValuePills: Bool
@@ -187,6 +188,7 @@ enum MainPopoverTodayTimesSectionEvent {
     case beginEditing(TodayTimeField)
     case applyEditing
     case cancelEditing
+    case deleteEndTime
     case draftChanged(MainPopoverTodayTimesDraft)
 }
 
@@ -197,6 +199,7 @@ final class MainPopoverTodayTimesSectionView: NSView {
     private let startTimeCancelButton = NSButton(title: "Cancel", target: nil, action: nil)
     private let endTimeApplyButton = NSButton(title: "Apply", target: nil, action: nil)
     private let endTimeCancelButton = NSButton(title: "Cancel", target: nil, action: nil)
+    private let endTimeDeleteButton = NSButton(title: MainPopoverCopy.english.deleteActionTitle, target: nil, action: nil)
 
     private let container = MainPopoverSectionContainerView(
         insets: MainPopoverStyle.Metrics.todayTimesInsets,
@@ -226,8 +229,13 @@ final class MainPopoverTodayTimesSectionView: NSView {
         startTimeCancelButton.isHidden = !renderModel.showsStartActions
         endTimeApplyButton.isHidden = !renderModel.showsEndActions
         endTimeCancelButton.isHidden = !renderModel.showsEndActions
+        endTimeDeleteButton.isHidden = !renderModel.showsEndDeleteAction
         startTimeApplyButton.isEnabled = renderModel.isApplyEnabled
         endTimeApplyButton.isEnabled = renderModel.isApplyEnabled
+    }
+
+    func setDeleteActionTitle(_ title: String) {
+        endTimeDeleteButton.title = title
     }
 
     func setEditingDraft(_ draft: MainPopoverTodayTimesDraft) {
@@ -251,6 +259,7 @@ final class MainPopoverTodayTimesSectionView: NSView {
             isStartCancelVisible: startTimeCancelButton.isHidden == false,
             isEndApplyVisible: endTimeApplyButton.isHidden == false,
             isEndCancelVisible: endTimeCancelButton.isHidden == false,
+            isEndDeleteVisible: endTimeDeleteButton.isHidden == false,
             isApplyEnabled: (
                 startTimeApplyButton.isHidden == false && startTimeApplyButton.isEnabled
             ) || (
@@ -271,7 +280,7 @@ final class MainPopoverTodayTimesSectionView: NSView {
         container.translatesAutoresizingMaskIntoConstraints = false
         container.contentStack.spacing = MainPopoverStyle.Metrics.todayTimesSpacing
 
-        [startTimeApplyButton, startTimeCancelButton, endTimeApplyButton, endTimeCancelButton].forEach { button in
+        [startTimeApplyButton, startTimeCancelButton, endTimeApplyButton, endTimeCancelButton, endTimeDeleteButton].forEach { button in
             button.bezelStyle = .rounded
             button.controlSize = .small
             button.target = self
@@ -280,11 +289,13 @@ final class MainPopoverTodayTimesSectionView: NSView {
         endTimeApplyButton.action = #selector(handleApplyEditing)
         startTimeCancelButton.action = #selector(handleCancelEditing)
         endTimeCancelButton.action = #selector(handleCancelEditing)
+        endTimeDeleteButton.action = #selector(handleDeleteEndTime)
 
         editingActionRow.orientation = .horizontal
         editingActionRow.alignment = .centerY
         editingActionRow.spacing = MainPopoverStyle.Metrics.actionRowSpacing
         editingActionRow.addArrangedSubview(NSView())
+        editingActionRow.addArrangedSubview(endTimeDeleteButton)
         editingActionRow.addArrangedSubview(startTimeCancelButton)
         editingActionRow.addArrangedSubview(startTimeApplyButton)
         editingActionRow.addArrangedSubview(endTimeCancelButton)
@@ -346,6 +357,11 @@ final class MainPopoverTodayTimesSectionView: NSView {
     @objc
     private func handleCancelEditing() {
         onEvent?(.cancelEditing)
+    }
+
+    @objc
+    private func handleDeleteEndTime() {
+        onEvent?(.deleteEndTime)
     }
 
 }

--- a/UI/MainPopover/MainPopoverViewController.swift
+++ b/UI/MainPopover/MainPopoverViewController.swift
@@ -160,6 +160,10 @@ final class MainPopoverViewController: NSViewController {
         todayTimesBinder.applyEditing()
     }
 
+    func deleteEndTime() {
+        todayTimesBinder.deleteEndTime()
+    }
+
     func setEditingPickerDate(_ date: Date, for field: TodayTimeField) {
         let currentDraft = todayTimesSectionView.currentDraft()
         let updatedDraft: MainPopoverTodayTimesDraft

--- a/WorkPulseTests/CurrentSessionCalculatorTests.swift
+++ b/WorkPulseTests/CurrentSessionCalculatorTests.swift
@@ -637,7 +637,7 @@ struct AppDelegateTests {
         let snapshot = controller.snapshot
 
         let persistedTodayRecord = try #require(
-            store.loadRecords().last(where: { Calendar.current.isDate($0.date, inSameDayAs: referenceDate) })
+            store.loadRecords().last(where: { Self.seoulCalendar.isDate($0.date, inSameDayAs: referenceDate) })
         )
         #expect(persistedTodayRecord.startTime == startTime)
         #expect(persistedTodayRecord.endTime == endTime)
@@ -646,6 +646,67 @@ struct AppDelegateTests {
         #expect(abs(snapshot.currentSession.progressFraction - 0.94) < 0.001)
         #expect(snapshot.summary.weeklyValueText == "15:30")
         #expect(snapshot.summary.monthlyValueText == "15:30")
+    }
+
+    @Test
+    @MainActor
+    func deletingSavedEndTimeResumesCurrentSessionAndDropsTodayFromSummaries() throws {
+        let referenceDate = try #require(
+            ISO8601DateFormatter().date(from: "2026-03-31T17:00:00+09:00")
+        )
+        let startTime = try #require(
+            ISO8601DateFormatter().date(from: "2026-03-31T09:00:00+09:00")
+        )
+        let originalEndTime = try #require(
+            ISO8601DateFormatter().date(from: "2026-03-31T16:00:00+09:00")
+        )
+        let mondayRecord = AttendanceRecord(
+            date: try #require(ISO8601DateFormatter().date(from: "2026-03-30T00:00:00+09:00")),
+            startTime: try #require(ISO8601DateFormatter().date(from: "2026-03-30T09:00:00+09:00")),
+            endTime: try #require(ISO8601DateFormatter().date(from: "2026-03-30T17:00:00+09:00"))
+        )
+        let store = InMemoryAttendanceRecordStore(records: [
+            mondayRecord,
+            AttendanceRecord(
+                date: try #require(ISO8601DateFormatter().date(from: "2026-03-31T00:00:00+09:00")),
+                startTime: startTime,
+                endTime: originalEndTime
+            )
+        ])
+        let controller = MainPopoverViewController(
+            state: MainPopoverViewStateFactory(copy: .english).makePlaceholder(),
+            currentSessionCalculator: CurrentSessionCalculator(
+                workedDurationCalculator: WorkedDurationCalculator(calendar: makeSeoulCalendar())
+            ),
+            currentTimeProvider: { referenceDate }
+        )
+        let appDelegate = AppDelegate(
+            runtimeDependencies: MainPopoverRuntimeDependencies(
+                calendar: Self.seoulCalendar,
+                locale: Locale(identifier: "en_US_POSIX"),
+                timeZone: try #require(TimeZone(secondsFromGMT: 9 * 60 * 60)),
+                currentDateProvider: { referenceDate },
+                currentSessionScheduler: FakeRepeatingScheduler()
+            ),
+            recordStore: store
+        )
+
+        controller.loadViewIfNeeded()
+        appDelegate.configurePopoverViewController(controller, referenceDate: referenceDate)
+        controller.beginEditing(.endTime)
+        controller.deleteEndTime()
+        let snapshot = controller.snapshot
+
+        let persistedTodayRecord = try #require(
+            store.loadRecords().last(where: { Self.seoulCalendar.isDate($0.date, inSameDayAs: referenceDate) })
+        )
+        #expect(persistedTodayRecord.startTime == startTime)
+        #expect(persistedTodayRecord.endTime == nil)
+        #expect(snapshot.todayTimes.endRow.valueText == "--:--")
+        #expect(snapshot.currentSession.valueText == "07:00:00")
+        #expect(abs(snapshot.currentSession.progressFraction - 0.875) < 0.001)
+        #expect(snapshot.summary.weeklyValueText == "07:00")
+        #expect(snapshot.summary.monthlyValueText == "07:00")
     }
 
     @Test

--- a/WorkPulseTests/MainPopoverRenderModelFactoryTests.swift
+++ b/WorkPulseTests/MainPopoverRenderModelFactoryTests.swift
@@ -34,6 +34,7 @@ struct MainPopoverRenderModelFactoryTests {
             showsEditingActions: false,
             showsStartActions: false,
             showsEndActions: false,
+            showsEndDeleteAction: false,
             isApplyEnabled: false
         )
 
@@ -62,6 +63,7 @@ struct MainPopoverRenderModelFactoryTests {
                 currentSessionLeadingCaption: "START",
                 startTimeTitle: "In",
                 endTimeTitle: "Out",
+                deleteActionTitle: "Delete",
                 weeklyTitle: "Week",
                 monthlyTitle: "Month",
                 currentSessionGoalLabelPrefix: "Target"
@@ -95,6 +97,7 @@ struct MainPopoverRenderModelFactoryTests {
                 showsEditingActions: false,
                 showsStartActions: false,
                 showsEndActions: false,
+                showsEndDeleteAction: false,
                 isApplyEnabled: false
             )
         )

--- a/WorkPulseTests/MainPopoverSectionViewsTests.swift
+++ b/WorkPulseTests/MainPopoverSectionViewsTests.swift
@@ -36,6 +36,7 @@ struct MainPopoverSectionViewsTests {
             showsEditingActions: true,
             showsStartActions: true,
             showsEndActions: false,
+            showsEndDeleteAction: false,
             isApplyEnabled: true
         )
 
@@ -67,6 +68,7 @@ struct MainPopoverSectionViewsTests {
             showsEditingActions: false,
             showsStartActions: false,
             showsEndActions: false,
+            showsEndDeleteAction: false,
             isApplyEnabled: false
         )
 
@@ -113,6 +115,7 @@ struct MainPopoverSectionViewsTests {
                 showsEditingActions: true,
                 showsStartActions: true,
                 showsEndActions: false,
+                showsEndDeleteAction: false,
                 isApplyEnabled: true
             )
         )
@@ -120,6 +123,37 @@ struct MainPopoverSectionViewsTests {
         section.simulatePickerChange(editedStartTime, for: .startTime)
 
         #expect(emittedDraft?.startTime == editedStartTime)
+    }
+
+    @Test
+    @MainActor
+    func deleteActionAppearsOnlyWhenEditingSavedEndTime() {
+        let section = MainPopoverTodayTimesSectionView(frame: NSRect(x: 0, y: 0, width: 392, height: 146))
+        section.apply(
+            MainPopoverTodayTimesRenderModel(
+                startRow: MainPopoverTimeRowRenderModel(
+                    titleText: "Start Time",
+                    valueText: "08:45",
+                    isValueVisible: true,
+                    isPickerVisible: false,
+                    pickerDateValue: Date(timeIntervalSince1970: 0)
+                ),
+                endRow: MainPopoverTimeRowRenderModel(
+                    titleText: "End Time",
+                    valueText: "18:00",
+                    isValueVisible: false,
+                    isPickerVisible: true,
+                    pickerDateValue: Date(timeIntervalSince1970: 0)
+                ),
+                showsEditingActions: true,
+                showsStartActions: false,
+                showsEndActions: true,
+                showsEndDeleteAction: true,
+                isApplyEnabled: true
+            )
+        )
+
+        #expect(section.snapshot.isEndDeleteVisible)
     }
 
     @Test

--- a/WorkPulseTests/MainPopoverViewControllerTests.swift
+++ b/WorkPulseTests/MainPopoverViewControllerTests.swift
@@ -332,6 +332,40 @@ struct MainPopoverTodayTimesBinderTests {
 
     @Test
     @MainActor
+    func deletingSavedEndTimeEmitsNilEndTimeAndReturnsToReadOnlyMode() throws {
+        let startTime = try #require(
+            ISO8601DateFormatter().date(from: "2026-03-31T09:00:00+09:00")
+        )
+        let originalEndTime = try #require(
+            ISO8601DateFormatter().date(from: "2026-03-31T18:30:00+09:00")
+        )
+        let (binder, section) = makeBinderAndSection()
+        var appliedTimes: MainPopoverAppliedTodayTimes?
+
+        binder.onDidApplyTimes = { applied in
+            appliedTimes = applied
+        }
+        binder.loadSavedTimes(startTime: startTime, endTime: originalEndTime)
+        binder.beginEditing(.endTime)
+        binder.deleteEndTime()
+        section.sectionView.apply(
+            binder.makeRenderModel(
+                viewState: makeViewState(startTimeText: "09:00", endTimeText: "--:--"),
+                fallbackTime: startTime
+            )
+        )
+        let snapshot = section.snapshot
+
+        #expect(appliedTimes?.startTime == startTime)
+        #expect(appliedTimes?.endTime == nil)
+        #expect(snapshot.endRow.valueText == "--:--")
+        #expect(snapshot.endRow.isValueVisible)
+        #expect(snapshot.endRow.isPickerVisible == false)
+        #expect(snapshot.isEndDeleteVisible == false)
+    }
+
+    @Test
+    @MainActor
     func applyingEndTimeEarlierThanStartTimeDoesNotEmitInvalidTimes() throws {
         let startTime = try #require(
             ISO8601DateFormatter().date(from: "2026-03-31T09:00:00+09:00")
@@ -501,6 +535,7 @@ struct MainPopoverViewStateFactoryTests {
             currentSessionLeadingCaption: "0H",
             startTimeTitle: "In",
             endTimeTitle: "Out",
+            deleteActionTitle: "Delete",
             weeklyTitle: "Week",
             monthlyTitle: "Month",
             currentSessionGoalLabelPrefix: "Goal:"


### PR DESCRIPTION
## Summary
- add a delete action when editing a saved end time in the main popover
- persist `endTime = nil` through the existing save/refresh path so current session and totals recalculate immediately
- add regression coverage for the binder, section view, render model, and AppDelegate integration path

## Why
- issue #24 requires a recovery path when a user enters the wrong end time
- deleting the saved end time should return the day to an in-progress session and keep the visible dashboard consistent

## Validation
- `xcodebuild -project WorkPulse.xcodeproj -scheme WorkPulse -destination 'platform=macOS' -derivedDataPath /tmp/WorkPulseDD19 -only-testing:WorkPulseTests/AppDelegateTests test`
- `make verify`

Closes #24