### PR TITLE
기능: 주간 및 월간 상세 화면을 추가

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -21,6 +21,7 @@ struct MainPopoverRuntimeDependencies {
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var menuBarShellController: MenuBarShellController?
+    private var monthlyHistoryWindowController: MonthlyHistoryWindowController?
     private let popoverCoordinator: MainPopoverCoordinator
 
     init(
@@ -51,6 +52,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             recordStore: resolvedRecordStore
         )
         super.init()
+        self.popoverCoordinator.onOpenMonthlyHistory = { [weak self] state in
+            self?.presentMonthlyHistory(state)
+        }
+        self.popoverCoordinator.onRefreshMonthlyHistory = { [weak self] state in
+            self?.monthlyHistoryWindowController?.apply(state)
+        }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -79,5 +86,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func handlePopoverWillOpen() {
         popoverCoordinator.handlePopoverWillOpen()
+    }
+
+    private func presentMonthlyHistory(_ state: MonthlyHistoryViewState) {
+        let windowController = monthlyHistoryWindowController ?? {
+            let controller = MonthlyHistoryWindowController()
+            controller.onWillCloseWindow = { [weak self] in
+                self?.monthlyHistoryWindowController = nil
+            }
+            monthlyHistoryWindowController = controller
+            return controller
+        }()
+
+        windowController.show(state: state)
     }
 }

--- a/App/MainPopoverCoordinator.swift
+++ b/App/MainPopoverCoordinator.swift
@@ -4,11 +4,15 @@ import AppKit
 final class MainPopoverCoordinator {
     private weak var popoverViewController: MainPopoverViewController?
     private var displayedReferenceDate: Date?
+    var onOpenMonthlyHistory: ((MonthlyHistoryViewState) -> Void)?
+    var onRefreshMonthlyHistory: ((MonthlyHistoryViewState) -> Void)?
     private let runtimeDependencies: MainPopoverRuntimeDependencies
     private let recordStore: any AttendanceRecordStore
     private let viewStateFactory: MainPopoverViewStateFactory
     private let stateLoader: MainPopoverStateLoader
     private let workedDurationCalculator: WorkedDurationCalculator
+    private let weeklyProgressLoader: MainPopoverWeeklyProgressLoader
+    private let monthlyHistoryLoader: MonthlyHistoryLoader
 
     init(
         runtimeDependencies: MainPopoverRuntimeDependencies,
@@ -28,6 +32,20 @@ final class MainPopoverCoordinator {
             recordStore: recordStore,
             viewStateFactory: viewStateFactory,
             calendar: runtimeDependencies.calendar
+        )
+        self.weeklyProgressLoader = MainPopoverWeeklyProgressLoader(
+            recordStore: recordStore,
+            calendar: runtimeDependencies.calendar,
+            locale: runtimeDependencies.locale,
+            timeZone: runtimeDependencies.timeZone,
+            currentDateProvider: runtimeDependencies.currentDateProvider
+        )
+        self.monthlyHistoryLoader = MonthlyHistoryLoader(
+            recordStore: recordStore,
+            calendar: runtimeDependencies.calendar,
+            locale: runtimeDependencies.locale,
+            timeZone: runtimeDependencies.timeZone,
+            currentDateProvider: runtimeDependencies.currentDateProvider
         )
     }
 
@@ -59,11 +77,18 @@ final class MainPopoverCoordinator {
         popoverViewController.onApplyEditedTimes = { [weak self] startTime, endTime in
             self?.handleAppliedTodayTimes(startTime: startTime, endTime: endTime)
         }
+        popoverViewController.onOpenWeeklyProgress = { [weak self] in
+            self?.showWeeklyProgress()
+        }
+        popoverViewController.onOpenMonthlyHistory = { [weak self] in
+            self?.showMonthlyHistory()
+        }
         refreshPopover(referenceDate: referenceDate)
     }
 
     func handlePopoverWillOpen() {
         let referenceDate = resolvedReferenceDate()
+        popoverViewController?.showMainView()
 
         if shouldResetEditingForReferenceDate(referenceDate) {
             popoverViewController?.cancelEditing()
@@ -121,6 +146,19 @@ final class MainPopoverCoordinator {
                 endTime: loadedState.todayRecord?.endTime
             )
         )
+        onRefreshMonthlyHistory?(monthlyHistoryLoader.load(referenceDate: referenceDate))
+    }
+
+    private func showWeeklyProgress() {
+        let referenceDate = resolvedReferenceDate()
+        popoverViewController?.showWeeklyDetail(
+            weeklyProgressLoader.load(referenceDate: referenceDate)
+        )
+    }
+
+    private func showMonthlyHistory() {
+        let referenceDate = resolvedReferenceDate()
+        onOpenMonthlyHistory?(monthlyHistoryLoader.load(referenceDate: referenceDate))
     }
 
     private func shouldResetEditingForReferenceDate(_ referenceDate: Date) -> Bool {

--- a/Feature/MainPopover/Presentation/MainPopoverCopy.swift
+++ b/Feature/MainPopover/Presentation/MainPopoverCopy.swift
@@ -12,8 +12,13 @@ struct MainPopoverCopy {
     let startTimeTitle: String
     let endTimeTitle: String
     let deleteActionTitle: String
+    let backActionTitle: String
     let weeklyTitle: String
     let monthlyTitle: String
+    let weeklyProgressTitle: String
+    let monthlyHistoryTitle: String
+    let monthlyHistoryEmptyText: String
+    let monthlyHistoryInProgressText: String
     let currentSessionGoalLabelPrefix: String
 
     static let english = MainPopoverCopy(
@@ -28,8 +33,13 @@ struct MainPopoverCopy {
         startTimeTitle: "Start Time",
         endTimeTitle: "End Time",
         deleteActionTitle: "Delete",
+        backActionTitle: "Back",
         weeklyTitle: "This Week",
         monthlyTitle: "This Month",
+        weeklyProgressTitle: "WEEKLY PROGRESS",
+        monthlyHistoryTitle: "MONTHLY HISTORY",
+        monthlyHistoryEmptyText: "No attendance records yet",
+        monthlyHistoryInProgressText: "In progress",
         currentSessionGoalLabelPrefix: "Goal:"
     )
 
@@ -44,5 +54,9 @@ struct MainPopoverCopy {
 
     func checkedInSummaryText(for timeText: String) -> String {
         "\(checkedInSummaryPrefix) \(timeText)"
+    }
+
+    func summaryTotalText(totalDurationText: String) -> String {
+        "Total: \(totalDurationText)"
     }
 }

--- a/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
+++ b/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
@@ -1,0 +1,147 @@
+import CoreGraphics
+import Foundation
+
+struct MainPopoverWeeklyProgressDayViewState {
+    let dayText: String
+    let workedText: String
+    let progressFraction: CGFloat
+    let isToday: Bool
+}
+
+struct MainPopoverWeeklyProgressViewState {
+    let titleText: String
+    let subtitleText: String
+    let totalText: String
+    let days: [MainPopoverWeeklyProgressDayViewState]
+}
+
+struct MainPopoverWeeklyProgressLoader {
+    private let recordStore: any AttendanceRecordQuerying
+    private let workedDurationCalculator: WorkedDurationCalculator
+    private let calendar: Calendar
+    private let currentDateProvider: () -> Date
+    private let copy: MainPopoverCopy
+    private let dayFormatter: DateFormatter
+    private let rangeFormatter: DateFormatter
+
+    init(
+        recordStore: any AttendanceRecordQuerying,
+        calendar: Calendar = .current,
+        locale: Locale = .current,
+        timeZone: TimeZone = .current,
+        currentDateProvider: @escaping () -> Date,
+        copy: MainPopoverCopy = .english
+    ) {
+        self.recordStore = recordStore
+        self.workedDurationCalculator = WorkedDurationCalculator(calendar: calendar)
+        self.calendar = calendar
+        self.currentDateProvider = currentDateProvider
+        self.copy = copy
+
+        let dayFormatter = DateFormatter()
+        dayFormatter.calendar = calendar
+        dayFormatter.locale = locale
+        dayFormatter.timeZone = timeZone
+        dayFormatter.dateFormat = "EEE d"
+        self.dayFormatter = dayFormatter
+
+        let rangeFormatter = DateFormatter()
+        rangeFormatter.calendar = calendar
+        rangeFormatter.locale = locale
+        rangeFormatter.timeZone = timeZone
+        rangeFormatter.dateFormat = "MMM d"
+        self.rangeFormatter = rangeFormatter
+    }
+
+    func load(referenceDate: Date) -> MainPopoverWeeklyProgressViewState {
+        let weekDates = makeWeekDates(for: referenceDate)
+        let currentDate = currentDateProvider()
+        let dayStatesWithDuration = weekDates.map { date in
+            let record = recordStore.record(on: date, calendar: calendar)
+            let duration = workedDuration(
+                for: record,
+                referenceDate: date,
+                currentDate: currentDate
+            )
+
+            return (
+                MainPopoverWeeklyProgressDayViewState(
+                    dayText: dayFormatter.string(from: date),
+                    workedText: formatDuration(duration),
+                    progressFraction: progressFraction(for: duration),
+                    isToday: calendar.isDate(date, inSameDayAs: referenceDate)
+                ),
+                duration
+            )
+        }
+        let totalDuration = dayStatesWithDuration
+            .compactMap(\.1)
+            .reduce(0, +)
+
+        return MainPopoverWeeklyProgressViewState(
+            titleText: copy.weeklyProgressTitle,
+            subtitleText: weekSubtitle(for: weekDates),
+            totalText: copy.summaryTotalText(totalDurationText: formatDuration(totalDuration)),
+            days: dayStatesWithDuration.map(\.0)
+        )
+    }
+
+    private func makeWeekDates(for referenceDate: Date) -> [Date] {
+        guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: referenceDate) else {
+            return [referenceDate]
+        }
+
+        let weekStart = calendar.startOfDay(for: weekInterval.start)
+        return (0..<7).compactMap { offset in
+            calendar.date(byAdding: .day, value: offset, to: weekStart)
+        }
+    }
+
+    private func weekSubtitle(for dates: [Date]) -> String {
+        guard let firstDate = dates.first, let lastDate = dates.last else {
+            return ""
+        }
+
+        return "\(rangeFormatter.string(from: firstDate)) - \(rangeFormatter.string(from: lastDate))"
+    }
+
+    private func workedDuration(
+        for record: AttendanceRecord?,
+        referenceDate: Date,
+        currentDate: Date
+    ) -> TimeInterval? {
+        guard let record else { return nil }
+        let effectiveEndTime: Date?
+
+        if let endTime = record.endTime {
+            effectiveEndTime = endTime
+        } else if record.startTime != nil, calendar.isDate(referenceDate, inSameDayAs: currentDate) {
+            effectiveEndTime = currentDate
+        } else {
+            effectiveEndTime = nil
+        }
+
+        return workedDurationCalculator.workedDuration(
+            startTime: record.startTime,
+            endTime: effectiveEndTime
+        )
+    }
+
+    private func formatDuration(_ duration: TimeInterval?) -> String {
+        guard let duration, duration > 0 else {
+            return copy.totalPlaceholderText
+        }
+
+        let totalMinutes = Int(duration) / 60
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+        return String(format: "%02d:%02d", hours, minutes)
+    }
+
+    private func progressFraction(for duration: TimeInterval?) -> CGFloat {
+        guard let duration, duration > 0 else { return 0 }
+
+        let fraction = CGFloat(duration / MainPopoverCurrentSessionProgressPolicy.defaultGoalDuration)
+        return min(1, max(0, fraction))
+    }
+}

--- a/Feature/MainPopover/Service/MonthlyHistoryLoader.swift
+++ b/Feature/MainPopover/Service/MonthlyHistoryLoader.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+struct MonthlyHistoryItemViewState {
+    let dateText: String
+    let timeRangeText: String
+    let workedDurationText: String
+    let isInProgress: Bool
+}
+
+struct MonthlyHistoryViewState {
+    let titleText: String
+    let subtitleText: String
+    let totalText: String
+    let emptyText: String
+    let items: [MonthlyHistoryItemViewState]
+}
+
+struct MonthlyHistoryLoader {
+    private let recordStore: any AttendanceRecordQuerying
+    private let totalsCalculator: AttendanceRecordTotalsCalculator
+    private let workedDurationCalculator: WorkedDurationCalculator
+    private let calendar: Calendar
+    private let currentDateProvider: () -> Date
+    private let copy: MainPopoverCopy
+    private let monthFormatter: DateFormatter
+    private let dateFormatter: DateFormatter
+    private let timeFormatter: DateFormatter
+
+    init(
+        recordStore: any AttendanceRecordQuerying,
+        totalsCalculator: AttendanceRecordTotalsCalculator = AttendanceRecordTotalsCalculator(),
+        calendar: Calendar = .current,
+        locale: Locale = .current,
+        timeZone: TimeZone = .current,
+        currentDateProvider: @escaping () -> Date,
+        copy: MainPopoverCopy = .english
+    ) {
+        self.recordStore = recordStore
+        self.totalsCalculator = totalsCalculator
+        self.workedDurationCalculator = WorkedDurationCalculator(calendar: calendar)
+        self.calendar = calendar
+        self.currentDateProvider = currentDateProvider
+        self.copy = copy
+
+        let monthFormatter = DateFormatter()
+        monthFormatter.calendar = calendar
+        monthFormatter.locale = locale
+        monthFormatter.timeZone = timeZone
+        monthFormatter.dateFormat = "MMMM yyyy"
+        self.monthFormatter = monthFormatter
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.calendar = calendar
+        dateFormatter.locale = locale
+        dateFormatter.timeZone = timeZone
+        dateFormatter.dateFormat = "EEE, MMM d"
+        self.dateFormatter = dateFormatter
+
+        let timeFormatter = DateFormatter()
+        timeFormatter.calendar = calendar
+        timeFormatter.locale = locale
+        timeFormatter.timeZone = timeZone
+        timeFormatter.dateFormat = "HH:mm"
+        self.timeFormatter = timeFormatter
+    }
+
+    func load(referenceDate: Date) -> MonthlyHistoryViewState {
+        let records = recordStore.records(
+            equalTo: referenceDate,
+            toGranularity: .month,
+            calendar: calendar
+        ).sorted { $0.date > $1.date }
+        let totalDuration = totalsCalculator.monthlyTotal(
+            records: records,
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+        let currentDate = currentDateProvider()
+
+        return MonthlyHistoryViewState(
+            titleText: copy.monthlyHistoryTitle,
+            subtitleText: monthFormatter.string(from: referenceDate),
+            totalText: copy.summaryTotalText(totalDurationText: formatWorkedDuration(totalDuration)),
+            emptyText: copy.monthlyHistoryEmptyText,
+            items: records.map { record in
+                makeItemState(record: record, currentDate: currentDate)
+            }
+        )
+    }
+
+    private func makeItemState(
+        record: AttendanceRecord,
+        currentDate: Date
+    ) -> MonthlyHistoryItemViewState {
+        let isInProgress =
+            record.startTime != nil &&
+            record.endTime == nil &&
+            calendar.isDate(record.date, inSameDayAs: currentDate)
+        let duration = workedDuration(
+            startTime: record.startTime,
+            endTime: record.endTime,
+            recordDate: record.date,
+            currentDate: currentDate
+        )
+
+        return MonthlyHistoryItemViewState(
+            dateText: dateFormatter.string(from: record.date),
+            timeRangeText: makeTimeRangeText(startTime: record.startTime, endTime: record.endTime),
+            workedDurationText: isInProgress ? copy.monthlyHistoryInProgressText : formatWorkedDuration(duration),
+            isInProgress: isInProgress
+        )
+    }
+
+    private func makeTimeRangeText(startTime: Date?, endTime: Date?) -> String {
+        "\(formatTime(startTime)) - \(formatTime(endTime))"
+    }
+
+    private func formatTime(_ date: Date?) -> String {
+        guard let date else {
+            return copy.timePlaceholderText
+        }
+
+        return timeFormatter.string(from: date)
+    }
+
+    private func formatWorkedDuration(_ duration: TimeInterval?) -> String {
+        guard let duration, duration > 0 else {
+            return copy.totalPlaceholderText
+        }
+
+        let totalMinutes = Int(duration) / 60
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+        return String(format: "%02d:%02d", hours, minutes)
+    }
+
+    private func workedDuration(
+        startTime: Date?,
+        endTime: Date?,
+        recordDate: Date,
+        currentDate: Date
+    ) -> TimeInterval? {
+        let effectiveEndTime: Date?
+
+        if let endTime {
+            effectiveEndTime = endTime
+        } else if startTime != nil, calendar.isDate(recordDate, inSameDayAs: currentDate) {
+            effectiveEndTime = currentDate
+        } else {
+            effectiveEndTime = nil
+        }
+
+        return workedDurationCalculator.workedDuration(
+            startTime: startTime,
+            endTime: effectiveEndTime
+        )
+    }
+}

--- a/UI/MainPopover/MainPopoverStyle.swift
+++ b/UI/MainPopover/MainPopoverStyle.swift
@@ -49,6 +49,10 @@ enum MainPopoverStyle {
         static let summaryRowSpacing: CGFloat = 12
         static let summaryTitleRowSpacing: CGFloat = 8
         static let actionRowSpacing: CGFloat = 8
+        static let weeklyDetailSpacing: CGFloat = 12
+        static let weeklyDetailRowSpacing: CGFloat = 10
+        static let monthlyHistoryRowSpacing: CGFloat = 10
+        static let monthlyHistoryWindowSize = NSSize(width: 440, height: 560)
 
         static let shadowOpacity: Float = 0.08
         static let shadowRadius: CGFloat = 10
@@ -57,6 +61,8 @@ enum MainPopoverStyle {
         static let valuePillBorderWidth: CGFloat = 1
         static let progressCornerRadius: CGFloat = 5
         static let valuePillCornerRadius: CGFloat = 12
+
+        static let weeklyDetailInsets = NSEdgeInsets(top: 18, left: 20, bottom: 20, right: 20)
     }
 
     enum Colors {

--- a/UI/MainPopover/MainPopoverSummarySectionView.swift
+++ b/UI/MainPopover/MainPopoverSummarySectionView.swift
@@ -1,5 +1,10 @@
 import AppKit
 
+enum MainPopoverSummarySelection: Equatable {
+    case weekly
+    case monthly
+}
+
 struct MainPopoverSummarySectionSnapshot {
     let weeklyTitleText: String
     let weeklyValueText: String
@@ -12,6 +17,8 @@ struct MainPopoverSummarySectionSnapshot {
 }
 
 final class MainPopoverSummarySectionView: NSView {
+    var onSelect: ((MainPopoverSummarySelection) -> Void)?
+
     private let weeklyTitleLabel = NSTextField(labelWithString: "")
     private let weeklyValueLabel = NSTextField(labelWithString: "")
     private let monthlyTitleLabel = NSTextField(labelWithString: "")
@@ -58,6 +65,20 @@ final class MainPopoverSummarySectionView: NSView {
         )
     }
 
+    func simulateSelection(_ selection: MainPopoverSummarySelection) {
+        onSelect?(selection)
+    }
+
+    @objc
+    private func handleWeeklySelection() {
+        onSelect?(.weekly)
+    }
+
+    @objc
+    private func handleMonthlySelection() {
+        onSelect?(.monthly)
+    }
+
     private func configure() {
         translatesAutoresizingMaskIntoConstraints = false
         addSubview(container)
@@ -100,6 +121,13 @@ final class MainPopoverSummarySectionView: NSView {
         monthlyColumn.orientation = .vertical
         monthlyColumn.alignment = .trailing
         monthlyColumn.spacing = MainPopoverStyle.Metrics.summarySpacing
+
+        weeklyColumn.addGestureRecognizer(
+            NSClickGestureRecognizer(target: self, action: #selector(handleWeeklySelection))
+        )
+        monthlyColumn.addGestureRecognizer(
+            NSClickGestureRecognizer(target: self, action: #selector(handleMonthlySelection))
+        )
 
         columnsRow.addArrangedSubview(weeklyColumn)
         columnsRow.addArrangedSubview(NSView())

--- a/UI/MainPopover/MainPopoverViewController.swift
+++ b/UI/MainPopover/MainPopoverViewController.swift
@@ -5,6 +5,13 @@ struct MainPopoverViewSnapshot {
     let currentSession: MainPopoverCurrentSessionSectionSnapshot
     let todayTimes: MainPopoverTodayTimesSectionSnapshot
     let summary: MainPopoverSummarySectionSnapshot
+    let weeklyDetail: MainPopoverWeeklyProgressSectionSnapshot
+    let isShowingWeeklyDetail: Bool
+}
+
+private enum MainPopoverRoute {
+    case main
+    case weeklyDetail
 }
 
 final class MainPopoverViewController: NSViewController {
@@ -15,11 +22,16 @@ final class MainPopoverViewController: NSViewController {
     private let currentSessionScheduler: any CurrentSessionScheduling
     private let renderModelFactory: MainPopoverRenderModelFactory
     var onApplyEditedTimes: ((Date?, Date?) -> Void)?
+    var onOpenWeeklyProgress: (() -> Void)?
+    var onOpenMonthlyHistory: (() -> Void)?
 
     private let headerSectionView = MainPopoverHeaderSectionView()
     private let currentSessionSectionView = MainPopoverCurrentSessionSectionView()
     private let todayTimesSectionView = MainPopoverTodayTimesSectionView()
     private let summarySectionView = MainPopoverSummarySectionView()
+    private let weeklyDetailSectionView = MainPopoverWeeklyProgressSectionView()
+    private let mainContentView = NSView()
+    private var route: MainPopoverRoute = .main
 
     private lazy var currentSessionBinder: MainPopoverCurrentSessionBinder = {
         let binder = MainPopoverCurrentSessionBinder(
@@ -63,6 +75,17 @@ final class MainPopoverViewController: NSViewController {
         self.currentSessionScheduler = currentSessionScheduler
         self.renderModelFactory = MainPopoverRenderModelFactory(copy: copy)
         super.init(nibName: nil, bundle: nil)
+        summarySectionView.onSelect = { [weak self] selection in
+            switch selection {
+            case .weekly:
+                self?.onOpenWeeklyProgress?()
+            case .monthly:
+                self?.onOpenMonthlyHistory?()
+            }
+        }
+        weeklyDetailSectionView.onBack = { [weak self] in
+            self?.showMainView()
+        }
     }
 
     @available(*, unavailable)
@@ -98,17 +121,30 @@ final class MainPopoverViewController: NSViewController {
             summarySectionView,
         ].forEach(contentStack.addArrangedSubview)
 
-        rootView.addSubview(contentStack)
+        mainContentView.translatesAutoresizingMaskIntoConstraints = false
+        mainContentView.addSubview(contentStack)
+        rootView.addSubview(mainContentView)
+        rootView.addSubview(weeklyDetailSectionView)
+        weeklyDetailSectionView.translatesAutoresizingMaskIntoConstraints = false
+        weeklyDetailSectionView.isHidden = true
 
         NSLayoutConstraint.activate([
-            contentStack.topAnchor.constraint(equalTo: rootView.topAnchor),
-            contentStack.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
-            contentStack.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
-            contentStack.bottomAnchor.constraint(lessThanOrEqualTo: rootView.bottomAnchor),
+            mainContentView.topAnchor.constraint(equalTo: rootView.topAnchor),
+            mainContentView.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
+            mainContentView.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
+            mainContentView.bottomAnchor.constraint(equalTo: rootView.bottomAnchor),
+            contentStack.topAnchor.constraint(equalTo: mainContentView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: mainContentView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: mainContentView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(lessThanOrEqualTo: mainContentView.bottomAnchor),
             headerSectionView.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
             currentSessionSectionView.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
             todayTimesSectionView.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
             summarySectionView.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
+            weeklyDetailSectionView.topAnchor.constraint(equalTo: rootView.topAnchor),
+            weeklyDetailSectionView.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
+            weeklyDetailSectionView.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
+            weeklyDetailSectionView.bottomAnchor.constraint(equalTo: rootView.bottomAnchor),
         ])
 
         view = rootView
@@ -141,6 +177,21 @@ final class MainPopoverViewController: NSViewController {
 
     func stopCurrentSessionUpdates() {
         currentSessionBinder.stop()
+    }
+
+    func showWeeklyDetail(_ state: MainPopoverWeeklyProgressViewState) {
+        weeklyDetailSectionView.apply(state)
+        route = .weeklyDetail
+        updateRoute()
+    }
+
+    func showMainView() {
+        route = .main
+        updateRoute()
+    }
+
+    var isShowingWeeklyDetail: Bool {
+        route == .weeklyDetail
     }
 
     override func viewDidDisappear() {
@@ -196,12 +247,20 @@ final class MainPopoverViewController: NSViewController {
         summarySectionView.apply(renderModel.summary)
     }
 
+    private func updateRoute() {
+        guard isViewLoaded else { return }
+        mainContentView.isHidden = route != .main
+        weeklyDetailSectionView.isHidden = route != .weeklyDetail
+    }
+
     var snapshot: MainPopoverViewSnapshot {
         MainPopoverViewSnapshot(
             header: headerSectionView.snapshot,
             currentSession: currentSessionSectionView.snapshot,
             todayTimes: todayTimesSectionView.snapshot,
-            summary: summarySectionView.snapshot
+            summary: summarySectionView.snapshot,
+            weeklyDetail: weeklyDetailSectionView.snapshot,
+            isShowingWeeklyDetail: isShowingWeeklyDetail
         )
     }
 }

--- a/UI/MainPopover/MainPopoverWeeklyProgressSectionView.swift
+++ b/UI/MainPopover/MainPopoverWeeklyProgressSectionView.swift
@@ -1,0 +1,166 @@
+import AppKit
+
+struct MainPopoverWeeklyProgressSectionSnapshot {
+    let titleText: String
+    let subtitleText: String
+    let totalText: String
+    let dayCount: Int
+    let isShowingBackButton: Bool
+}
+
+private final class MainPopoverWeeklyProgressDayRowView: NSView {
+    private let dayLabel = NSTextField(labelWithString: "")
+    private let workedLabel = NSTextField(labelWithString: "")
+    private let progressBar = CurrentSessionProgressBarView()
+    private let row = NSStackView()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        dayLabel.font = MainPopoverStyle.Typography.sectionTitle
+        dayLabel.textColor = MainPopoverStyle.Colors.primaryText
+
+        workedLabel.font = MainPopoverStyle.Typography.progressCaption
+        workedLabel.textColor = MainPopoverStyle.Colors.secondaryText
+        workedLabel.alignment = .right
+
+        progressBar.applyVisualState(.normal)
+
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = 12
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.addArrangedSubview(dayLabel)
+        row.addArrangedSubview(progressBar)
+        row.addArrangedSubview(workedLabel)
+
+        addSubview(row)
+
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(equalTo: topAnchor),
+            row.leadingAnchor.constraint(equalTo: leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: trailingAnchor),
+            row.bottomAnchor.constraint(equalTo: bottomAnchor),
+            progressBar.widthAnchor.constraint(greaterThanOrEqualToConstant: 120),
+            workedLabel.widthAnchor.constraint(equalToConstant: 48),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func apply(_ state: MainPopoverWeeklyProgressDayViewState) {
+        dayLabel.stringValue = state.dayText
+        dayLabel.textColor = state.isToday
+            ? MainPopoverStyle.Colors.currentSessionValue
+            : MainPopoverStyle.Colors.primaryText
+        workedLabel.stringValue = state.workedText
+        progressBar.progressFraction = state.progressFraction
+    }
+}
+
+final class MainPopoverWeeklyProgressSectionView: NSView {
+    var onBack: (() -> Void)?
+
+    private let backButton = NSButton(title: "", target: nil, action: nil)
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let subtitleLabel = NSTextField(labelWithString: "")
+    private let totalLabel = NSTextField(labelWithString: "")
+    private let rowsStack = NSStackView()
+    private let container = MainPopoverSectionContainerView(
+        insets: MainPopoverStyle.Metrics.weeklyDetailInsets
+    )
+    private var rowViews: [MainPopoverWeeklyProgressDayRowView] = []
+
+    init(copy: MainPopoverCopy = .english) {
+        super.init(frame: .zero)
+        backButton.title = copy.backActionTitle
+        configure()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func apply(_ state: MainPopoverWeeklyProgressViewState) {
+        titleLabel.stringValue = state.titleText
+        subtitleLabel.stringValue = state.subtitleText
+        totalLabel.stringValue = state.totalText
+        syncRows(count: state.days.count)
+
+        zip(rowViews, state.days).forEach { row, day in
+            row.apply(day)
+        }
+    }
+
+    var snapshot: MainPopoverWeeklyProgressSectionSnapshot {
+        MainPopoverWeeklyProgressSectionSnapshot(
+            titleText: titleLabel.stringValue,
+            subtitleText: subtitleLabel.stringValue,
+            totalText: totalLabel.stringValue,
+            dayCount: rowViews.count,
+            isShowingBackButton: backButton.isHidden == false
+        )
+    }
+
+    @objc
+    private func handleBack() {
+        onBack?()
+    }
+
+    private func configure() {
+        translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(container)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.contentStack.spacing = MainPopoverStyle.Metrics.weeklyDetailSpacing
+
+        backButton.bezelStyle = .inline
+        backButton.target = self
+        backButton.action = #selector(handleBack)
+
+        titleLabel.font = MainPopoverStyle.Typography.dateTitle
+        titleLabel.textColor = MainPopoverStyle.Colors.primaryText
+
+        subtitleLabel.font = MainPopoverStyle.Typography.secondary
+        subtitleLabel.textColor = MainPopoverStyle.Colors.secondaryText
+
+        totalLabel.font = MainPopoverStyle.Typography.summaryValue
+        totalLabel.textColor = MainPopoverStyle.Colors.primaryText
+
+        rowsStack.orientation = .vertical
+        rowsStack.alignment = .leading
+        rowsStack.spacing = MainPopoverStyle.Metrics.weeklyDetailRowSpacing
+
+        container.contentStack.addArrangedSubview(backButton)
+        container.contentStack.addArrangedSubview(titleLabel)
+        container.contentStack.addArrangedSubview(subtitleLabel)
+        container.contentStack.addArrangedSubview(totalLabel)
+        container.contentStack.addArrangedSubview(rowsStack)
+
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: topAnchor),
+            container.leadingAnchor.constraint(equalTo: leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: trailingAnchor),
+            container.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    private func syncRows(count: Int) {
+        while rowViews.count < count {
+            let rowView = MainPopoverWeeklyProgressDayRowView()
+            rowViews.append(rowView)
+            rowsStack.addArrangedSubview(rowView)
+        }
+
+        while rowViews.count > count {
+            let rowView = rowViews.removeLast()
+            rowsStack.removeArrangedSubview(rowView)
+            rowView.removeFromSuperview()
+        }
+    }
+}

--- a/UI/MonthlyHistory/MonthlyHistoryViewController.swift
+++ b/UI/MonthlyHistory/MonthlyHistoryViewController.swift
@@ -1,0 +1,179 @@
+import AppKit
+
+private final class MonthlyHistoryRowView: NSView {
+    private let dateLabel = NSTextField(labelWithString: "")
+    private let timeRangeLabel = NSTextField(labelWithString: "")
+    private let workedDurationLabel = NSTextField(labelWithString: "")
+    private let row = NSStackView()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+        layer?.backgroundColor = MainPopoverStyle.Colors.todayTimesBackground.cgColor
+        layer?.cornerRadius = MainPopoverStyle.Metrics.valuePillCornerRadius
+
+        dateLabel.font = MainPopoverStyle.Typography.sectionTitle
+        dateLabel.textColor = MainPopoverStyle.Colors.primaryText
+
+        timeRangeLabel.font = MainPopoverStyle.Typography.secondary
+        timeRangeLabel.textColor = MainPopoverStyle.Colors.secondaryText
+
+        workedDurationLabel.font = MainPopoverStyle.Typography.rowValue
+        workedDurationLabel.textColor = MainPopoverStyle.Colors.primaryText
+        workedDurationLabel.alignment = .right
+
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = 12
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.addArrangedSubview(dateLabel)
+        row.addArrangedSubview(timeRangeLabel)
+        row.addArrangedSubview(NSView())
+        row.addArrangedSubview(workedDurationLabel)
+
+        addSubview(row)
+
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+            row.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+            row.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+            row.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
+            workedDurationLabel.widthAnchor.constraint(equalToConstant: 88),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func apply(_ state: MonthlyHistoryItemViewState) {
+        dateLabel.stringValue = state.dateText
+        timeRangeLabel.stringValue = state.timeRangeText
+        workedDurationLabel.stringValue = state.workedDurationText
+        workedDurationLabel.textColor = state.isInProgress
+            ? MainPopoverStyle.Colors.currentSessionValue
+            : MainPopoverStyle.Colors.primaryText
+    }
+}
+
+@MainActor
+final class MonthlyHistoryViewController: NSViewController {
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let subtitleLabel = NSTextField(labelWithString: "")
+    private let totalLabel = NSTextField(labelWithString: "")
+    private let emptyLabel = NSTextField(labelWithString: "")
+    private let rowsStack = NSStackView()
+    private let scrollView = NSScrollView()
+    private var rowViews: [MonthlyHistoryRowView] = []
+
+    override func loadView() {
+        let rootView = NSView(
+            frame: NSRect(
+                x: 0,
+                y: 0,
+                width: MainPopoverStyle.Metrics.monthlyHistoryWindowSize.width,
+                height: MainPopoverStyle.Metrics.monthlyHistoryWindowSize.height
+            )
+        )
+        rootView.wantsLayer = true
+        rootView.layer?.backgroundColor = MainPopoverStyle.Colors.popoverBackground.cgColor
+
+        titleLabel.font = MainPopoverStyle.Typography.dateTitle
+        titleLabel.textColor = MainPopoverStyle.Colors.primaryText
+
+        subtitleLabel.font = MainPopoverStyle.Typography.secondary
+        subtitleLabel.textColor = MainPopoverStyle.Colors.secondaryText
+
+        totalLabel.font = MainPopoverStyle.Typography.summaryValue
+        totalLabel.textColor = MainPopoverStyle.Colors.primaryText
+
+        emptyLabel.font = MainPopoverStyle.Typography.secondary
+        emptyLabel.textColor = MainPopoverStyle.Colors.secondaryText
+        emptyLabel.alignment = .center
+        emptyLabel.isHidden = true
+
+        rowsStack.orientation = .vertical
+        rowsStack.alignment = .leading
+        rowsStack.spacing = MainPopoverStyle.Metrics.monthlyHistoryRowSpacing
+        rowsStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let documentView = NSView()
+        documentView.translatesAutoresizingMaskIntoConstraints = false
+        documentView.addSubview(rowsStack)
+        NSLayoutConstraint.activate([
+            rowsStack.topAnchor.constraint(equalTo: documentView.topAnchor),
+            rowsStack.leadingAnchor.constraint(equalTo: documentView.leadingAnchor),
+            rowsStack.trailingAnchor.constraint(equalTo: documentView.trailingAnchor),
+            rowsStack.bottomAnchor.constraint(equalTo: documentView.bottomAnchor),
+            rowsStack.widthAnchor.constraint(equalTo: documentView.widthAnchor),
+        ])
+
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = true
+        scrollView.borderType = .noBorder
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = documentView
+
+        rootView.addSubview(titleLabel)
+        rootView.addSubview(subtitleLabel)
+        rootView.addSubview(totalLabel)
+        rootView.addSubview(emptyLabel)
+        rootView.addSubview(scrollView)
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        totalLabel.translatesAutoresizingMaskIntoConstraints = false
+        emptyLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: rootView.topAnchor, constant: 20),
+            titleLabel.leadingAnchor.constraint(equalTo: rootView.leadingAnchor, constant: 20),
+            titleLabel.trailingAnchor.constraint(equalTo: rootView.trailingAnchor, constant: -20),
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 6),
+            subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            subtitleLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            totalLabel.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 12),
+            totalLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            totalLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: totalLabel.bottomAnchor, constant: 16),
+            scrollView.leadingAnchor.constraint(equalTo: rootView.leadingAnchor, constant: 20),
+            scrollView.trailingAnchor.constraint(equalTo: rootView.trailingAnchor, constant: -20),
+            scrollView.bottomAnchor.constraint(equalTo: rootView.bottomAnchor, constant: -20),
+            emptyLabel.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
+            emptyLabel.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor),
+            documentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor),
+        ])
+
+        view = rootView
+    }
+
+    func apply(_ state: MonthlyHistoryViewState) {
+        loadViewIfNeeded()
+        titleLabel.stringValue = state.titleText
+        subtitleLabel.stringValue = state.subtitleText
+        totalLabel.stringValue = state.totalText
+        emptyLabel.stringValue = state.emptyText
+        emptyLabel.isHidden = state.items.isEmpty == false
+        syncRows(count: state.items.count)
+
+        zip(rowViews, state.items).forEach { row, item in
+            row.apply(item)
+        }
+    }
+
+    private func syncRows(count: Int) {
+        while rowViews.count < count {
+            let rowView = MonthlyHistoryRowView()
+            rowViews.append(rowView)
+            rowsStack.addArrangedSubview(rowView)
+        }
+
+        while rowViews.count > count {
+            let rowView = rowViews.removeLast()
+            rowsStack.removeArrangedSubview(rowView)
+            rowView.removeFromSuperview()
+        }
+    }
+}

--- a/UI/MonthlyHistory/MonthlyHistoryWindowController.swift
+++ b/UI/MonthlyHistory/MonthlyHistoryWindowController.swift
@@ -1,0 +1,49 @@
+import AppKit
+
+@MainActor
+final class MonthlyHistoryWindowController: NSWindowController, NSWindowDelegate {
+    var onWillCloseWindow: (() -> Void)?
+
+    private let monthlyHistoryViewController = MonthlyHistoryViewController()
+
+    init() {
+        let window = NSWindow(
+            contentRect: NSRect(
+                x: 0,
+                y: 0,
+                width: MainPopoverStyle.Metrics.monthlyHistoryWindowSize.width,
+                height: MainPopoverStyle.Metrics.monthlyHistoryWindowSize.height
+            ),
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.center()
+        window.title = MainPopoverCopy.english.monthlyHistoryTitle
+        window.contentViewController = monthlyHistoryViewController
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func show(state: MonthlyHistoryViewState) {
+        monthlyHistoryViewController.apply(state)
+        window?.title = state.titleText
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func apply(_ state: MonthlyHistoryViewState) {
+        monthlyHistoryViewController.apply(state)
+        window?.title = state.titleText
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        onWillCloseWindow?()
+    }
+}

--- a/WorkPulse.xcodeproj/project.pbxproj
+++ b/WorkPulse.xcodeproj/project.pbxproj
@@ -37,12 +37,18 @@
 		A1B2C3D4E5F600000000002A /* TodayTimeField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60000000000A5 /* TodayTimeField.swift */; };
 		A1B2C3D4E5F600000000002B /* TodayTimeEditModeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60000000000A6 /* TodayTimeEditModeState.swift */; };
 		A1B2C3D4E5F600000000002C /* WorkedDurationCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60000000000A7 /* WorkedDurationCalculator.swift */; };
+		A1B2C3D4E5F60000000000B1 /* MainPopoverWeeklyProgressLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60000000000C1 /* MainPopoverWeeklyProgressLoader.swift */; };
+		A1B2C3D4E5F60000000000B2 /* MonthlyHistoryLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60000000000C2 /* MonthlyHistoryLoader.swift */; };
+		A1B2C3D4E5F60000000000B3 /* MainPopoverWeeklyProgressSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60000000000C3 /* MainPopoverWeeklyProgressSectionView.swift */; };
+		A1B2C3D4E5F60000000000B4 /* MonthlyHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60000000000C4 /* MonthlyHistoryViewController.swift */; };
+		A1B2C3D4E5F60000000000B5 /* MonthlyHistoryWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60000000000C5 /* MonthlyHistoryWindowController.swift */; };
 		B1C2D3E4F5A6000000000001 /* MenuBarShellControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6000000000011 /* MenuBarShellControllerTests.swift */; };
 		B1C2D3E4F5A6000000000002 /* MainPopoverViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6000000000013 /* MainPopoverViewControllerTests.swift */; };
 		B1C2D3E4F5A6000000000003 /* CurrentSessionCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6000000000014 /* CurrentSessionCalculatorTests.swift */; };
 		B1C2D3E4F5A6000000000004 /* MainPopoverRenderModelFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6000000000015 /* MainPopoverRenderModelFactoryTests.swift */; };
 		B1C2D3E4F5A6000000000005 /* MainPopoverCurrentSessionProgressPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6000000000016 /* MainPopoverCurrentSessionProgressPolicyTests.swift */; };
 		B1C2D3E4F5A6000000000006 /* MainPopoverSectionViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6000000000017 /* MainPopoverSectionViewsTests.swift */; };
+		B1C2D3E4F5A6000000000007 /* MainPopoverDetailNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6000000000018 /* MainPopoverDetailNavigationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +94,11 @@
 		A1B2C3D4E5F60000000000A5 /* TodayTimeField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayTimeField.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60000000000A6 /* TodayTimeEditModeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayTimeEditModeState.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60000000000A7 /* WorkedDurationCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkedDurationCalculator.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60000000000C1 /* MainPopoverWeeklyProgressLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPopoverWeeklyProgressLoader.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60000000000C2 /* MonthlyHistoryLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyHistoryLoader.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60000000000C3 /* MainPopoverWeeklyProgressSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPopoverWeeklyProgressSectionView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60000000000C4 /* MonthlyHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyHistoryViewController.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60000000000C5 /* MonthlyHistoryWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyHistoryWindowController.swift; sourceTree = "<group>"; };
 		B1C2D3E4F5A6000000000011 /* MenuBarShellControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarShellControllerTests.swift; sourceTree = "<group>"; };
 		B1C2D3E4F5A6000000000012 /* WorkPulseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WorkPulseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1C2D3E4F5A6000000000013 /* MainPopoverViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPopoverViewControllerTests.swift; sourceTree = "<group>"; };
@@ -95,6 +106,7 @@
 		B1C2D3E4F5A6000000000015 /* MainPopoverRenderModelFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPopoverRenderModelFactoryTests.swift; sourceTree = "<group>"; };
 		B1C2D3E4F5A6000000000016 /* MainPopoverCurrentSessionProgressPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPopoverCurrentSessionProgressPolicyTests.swift; sourceTree = "<group>"; };
 		B1C2D3E4F5A6000000000017 /* MainPopoverSectionViewsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPopoverSectionViewsTests.swift; sourceTree = "<group>"; };
+		B1C2D3E4F5A6000000000018 /* MainPopoverDetailNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPopoverDetailNavigationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +156,7 @@
 			sourceTree = "<group>";
 			children = (
 				A1B2C3D4E5F6000000000035 /* MainPopover */,
+				A1B2C3D4E5F60000000000D1 /* MonthlyHistory */,
 			);
 		};
 		A1B2C3D4E5F6000000000034 /* Products */ = {
@@ -172,8 +185,18 @@
 				A1B2C3D4E5F6000000000092 /* MainPopoverStyle.swift */,
 				A1B2C3D4E5F60000000000A1 /* MainPopoverTodayTimesBinder.swift */,
 				A1B2C3D4E5F600000000009A /* MainPopoverTodayTimesSectionView.swift */,
+				A1B2C3D4E5F60000000000C3 /* MainPopoverWeeklyProgressSectionView.swift */,
 				A1B2C3D4E5F600000000009C /* MainPopoverViewState.swift */,
 				A1B2C3D4E5F6000000000014 /* MainPopoverViewController.swift */,
+			);
+		};
+		A1B2C3D4E5F60000000000D1 /* MonthlyHistory */ = {
+			isa = PBXGroup;
+			path = MonthlyHistory;
+			sourceTree = "<group>";
+			children = (
+				A1B2C3D4E5F60000000000C4 /* MonthlyHistoryViewController.swift */,
+				A1B2C3D4E5F60000000000C5 /* MonthlyHistoryWindowController.swift */,
 			);
 		};
 		A1B2C3D4E5F6000000000036 /* Feature */ = {
@@ -202,6 +225,8 @@
 				A1B2C3D4E5F6000000000019 /* AttendanceRecordTotalsCalculator.swift */,
 				A1B2C3D4E5F6000000000017 /* CurrentSessionCalculator.swift */,
 				A1B2C3D4E5F6000000000091 /* MainPopoverStateLoader.swift */,
+				A1B2C3D4E5F60000000000C1 /* MainPopoverWeeklyProgressLoader.swift */,
+				A1B2C3D4E5F60000000000C2 /* MonthlyHistoryLoader.swift */,
 				A1B2C3D4E5F60000000000A7 /* WorkedDurationCalculator.swift */,
 			);
 		};
@@ -233,6 +258,7 @@
 			sourceTree = "<group>";
 			children = (
 				B1C2D3E4F5A6000000000014 /* CurrentSessionCalculatorTests.swift */,
+				B1C2D3E4F5A6000000000018 /* MainPopoverDetailNavigationTests.swift */,
 				B1C2D3E4F5A6000000000016 /* MainPopoverCurrentSessionProgressPolicyTests.swift */,
 				B1C2D3E4F5A6000000000015 /* MainPopoverRenderModelFactoryTests.swift */,
 				B1C2D3E4F5A6000000000017 /* MainPopoverSectionViewsTests.swift */,
@@ -352,6 +378,7 @@
 				A1B2C3D4E5F6000000000028 /* MainPopoverCoordinator.swift in Sources */,
 				A1B2C3D4E5F600000000000C /* MainPopoverRenderModelFactory.swift in Sources */,
 				A1B2C3D4E5F600000000001B /* MainPopoverCurrentSessionSectionView.swift in Sources */,
+				A1B2C3D4E5F60000000000B3 /* MainPopoverWeeklyProgressSectionView.swift in Sources */,
 				A1B2C3D4E5F6000000000020 /* MainPopoverDividerView.swift in Sources */,
 				A1B2C3D4E5F600000000001A /* MainPopoverHeaderSectionView.swift in Sources */,
 				A1B2C3D4E5F600000000000F /* MainPopoverSectionSupport.swift in Sources */,
@@ -361,6 +388,10 @@
 				A1B2C3D4E5F6000000000026 /* MainPopoverTodayTimesBinder.swift in Sources */,
 				A1B2C3D4E5F600000000001C /* MainPopoverTodayTimesSectionView.swift in Sources */,
 				A1B2C3D4E5F600000000001E /* MainPopoverViewState.swift in Sources */,
+				A1B2C3D4E5F60000000000B1 /* MainPopoverWeeklyProgressLoader.swift in Sources */,
+				A1B2C3D4E5F60000000000B2 /* MonthlyHistoryLoader.swift in Sources */,
+				A1B2C3D4E5F60000000000B4 /* MonthlyHistoryViewController.swift in Sources */,
+				A1B2C3D4E5F60000000000B5 /* MonthlyHistoryWindowController.swift in Sources */,
 				A1B2C3D4E5F600000000002C /* WorkedDurationCalculator.swift in Sources */,
 				A1B2C3D4E5F6000000000006 /* MainPopoverViewStateFactory.swift in Sources */,
 				A1B2C3D4E5F6000000000004 /* MainPopoverViewController.swift in Sources */,
@@ -376,6 +407,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B1C2D3E4F5A6000000000003 /* CurrentSessionCalculatorTests.swift in Sources */,
+				B1C2D3E4F5A6000000000007 /* MainPopoverDetailNavigationTests.swift in Sources */,
 				B1C2D3E4F5A6000000000005 /* MainPopoverCurrentSessionProgressPolicyTests.swift in Sources */,
 				B1C2D3E4F5A6000000000004 /* MainPopoverRenderModelFactoryTests.swift in Sources */,
 				B1C2D3E4F5A6000000000006 /* MainPopoverSectionViewsTests.swift in Sources */,

--- a/WorkPulseTests/MainPopoverDetailNavigationTests.swift
+++ b/WorkPulseTests/MainPopoverDetailNavigationTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Testing
+@testable import WorkPulse
+
+@Suite("MainPopoverDetailNavigation")
+struct MainPopoverDetailNavigationTests {
+    @Test
+    @MainActor
+    func summarySectionEmitsWeeklyAndMonthlySelections() {
+        let section = MainPopoverSummarySectionView()
+        var selections: [MainPopoverSummarySelection] = []
+
+        section.onSelect = { selections.append($0) }
+        section.simulateSelection(.weekly)
+        section.simulateSelection(.monthly)
+
+        #expect(selections.count == 2)
+        #expect(selections[0] == .weekly)
+        #expect(selections[1] == .monthly)
+    }
+
+    @Test
+    @MainActor
+    func viewControllerShowsWeeklyDetailAndReturnsToMain() {
+        let controller = MainPopoverViewController(
+            state: MainPopoverViewStateFactory(copy: .english).makePlaceholder(),
+            currentTimeProvider: { Date(timeIntervalSince1970: 0) }
+        )
+        let weeklyState = MainPopoverWeeklyProgressViewState(
+            titleText: "WEEKLY PROGRESS",
+            subtitleText: "Mar 30 - Apr 5",
+            totalText: "Total: 16:00",
+            days: [
+                MainPopoverWeeklyProgressDayViewState(
+                    dayText: "Mon 30",
+                    workedText: "08:00",
+                    progressFraction: 1,
+                    isToday: false
+                )
+            ]
+        )
+
+        controller.loadViewIfNeeded()
+        controller.showWeeklyDetail(weeklyState)
+
+        #expect(controller.snapshot.isShowingWeeklyDetail)
+        #expect(controller.snapshot.weeklyDetail.titleText == "WEEKLY PROGRESS")
+        #expect(controller.snapshot.weeklyDetail.dayCount == 1)
+
+        controller.showMainView()
+
+        #expect(controller.snapshot.isShowingWeeklyDetail == false)
+    }
+}
+
+@Suite("MainPopoverDetailLoaders")
+struct MainPopoverDetailLoadersTests {
+    @Test
+    func weeklyProgressLoaderBuildsSevenDaysAndFormatsTotal() throws {
+        let referenceDate = try #require(
+            makeDate("2026-04-01T12:00:00+09:00")
+        )
+        let store = DetailTestAttendanceRecordStore(records: [
+            AttendanceRecord(
+                date: try #require(makeDate("2026-03-30T00:00:00+09:00")),
+                startTime: try #require(makeDate("2026-03-30T09:00:00+09:00")),
+                endTime: try #require(makeDate("2026-03-30T18:00:00+09:00"))
+            ),
+            AttendanceRecord(
+                date: try #require(makeDate("2026-03-31T00:00:00+09:00")),
+                startTime: try #require(makeDate("2026-03-31T09:00:00+09:00")),
+                endTime: try #require(makeDate("2026-03-31T18:00:00+09:00"))
+            )
+        ])
+        let loader = MainPopoverWeeklyProgressLoader(
+            recordStore: store,
+            calendar: makeSeoulCalendar(),
+            locale: Locale(identifier: "en_US_POSIX"),
+            timeZone: TimeZone(identifier: "Asia/Seoul")!,
+            currentDateProvider: { referenceDate }
+        )
+
+        let state = loader.load(referenceDate: referenceDate)
+
+        #expect(state.titleText == "WEEKLY PROGRESS")
+        #expect(state.days.count == 7)
+        #expect(state.totalText == "Total: 16:00")
+        #expect(state.days.contains(where: { $0.isToday }))
+    }
+
+    @Test
+    func weeklyProgressLoaderIncludesInProgressTodayInTotal() throws {
+        let referenceDate = try #require(
+            makeDate("2026-04-01T12:00:00+09:00")
+        )
+        let store = DetailTestAttendanceRecordStore(records: [
+            AttendanceRecord(
+                date: try #require(makeDate("2026-03-30T00:00:00+09:00")),
+                startTime: try #require(makeDate("2026-03-30T09:00:00+09:00")),
+                endTime: try #require(makeDate("2026-03-30T18:00:00+09:00"))
+            ),
+            AttendanceRecord(
+                date: try #require(makeDate("2026-04-01T00:00:00+09:00")),
+                startTime: try #require(makeDate("2026-04-01T09:00:00+09:00")),
+                endTime: nil
+            )
+        ])
+        let loader = MainPopoverWeeklyProgressLoader(
+            recordStore: store,
+            calendar: makeSeoulCalendar(),
+            locale: Locale(identifier: "en_US_POSIX"),
+            timeZone: TimeZone(identifier: "Asia/Seoul")!,
+            currentDateProvider: { referenceDate }
+        )
+
+        let state = loader.load(referenceDate: referenceDate)
+
+        #expect(state.totalText == "Total: 11:00")
+        #expect(state.days.first(where: { $0.isToday })?.workedText == "03:00")
+    }
+
+    @Test
+    func monthlyHistoryLoaderSortsNewestFirstAndMarksInProgressRows() throws {
+        let referenceDate = try #require(
+            makeDate("2026-04-02T10:00:00+09:00")
+        )
+        let store = DetailTestAttendanceRecordStore(records: [
+            AttendanceRecord(
+                date: try #require(makeDate("2026-04-01T00:00:00+09:00")),
+                startTime: try #require(makeDate("2026-04-01T09:00:00+09:00")),
+                endTime: nil
+            ),
+            AttendanceRecord(
+                date: try #require(makeDate("2026-04-02T00:00:00+09:00")),
+                startTime: try #require(makeDate("2026-04-02T08:45:00+09:00")),
+                endTime: nil
+            )
+        ])
+        let loader = MonthlyHistoryLoader(
+            recordStore: store,
+            calendar: makeSeoulCalendar(),
+            locale: Locale(identifier: "en_US_POSIX"),
+            timeZone: TimeZone(identifier: "Asia/Seoul")!,
+            currentDateProvider: { referenceDate }
+        )
+
+        let state = loader.load(referenceDate: referenceDate)
+
+        #expect(state.titleText == "MONTHLY HISTORY")
+        #expect(state.items.count == 2)
+        #expect(state.items[0].isInProgress)
+        #expect(state.items[0].workedDurationText == "In progress")
+        #expect(state.items[1].isInProgress == false)
+        #expect(state.items[1].workedDurationText == "--")
+    }
+}
+
+private struct DetailTestAttendanceRecordStore: AttendanceRecordStore {
+    let records: [AttendanceRecord]
+
+    func record(on date: Date, calendar: Calendar) -> AttendanceRecord? {
+        records.last { calendar.isDate($0.date, inSameDayAs: date) }
+    }
+
+    func records(equalTo date: Date, toGranularity granularity: Calendar.Component, calendar: Calendar) -> [AttendanceRecord] {
+        records.filter { calendar.isDate($0.date, equalTo: date, toGranularity: granularity) }
+    }
+
+    func upsertRecord(_ record: AttendanceRecord) throws {
+        Issue.record("upsertRecord should not be called in detail loader tests")
+    }
+}
+
+private func makeDate(_ value: String) -> Date? {
+    ISO8601DateFormatter().date(from: value)
+}
+
+private func makeSeoulCalendar() -> Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+    calendar.locale = Locale(identifier: "ko_KR")
+    return calendar
+}

--- a/WorkPulseTests/MainPopoverRenderModelFactoryTests.swift
+++ b/WorkPulseTests/MainPopoverRenderModelFactoryTests.swift
@@ -66,8 +66,13 @@ struct MainPopoverRenderModelFactoryTests {
                 startTimeTitle: "In",
                 endTimeTitle: "Out",
                 deleteActionTitle: "Delete",
+                backActionTitle: "Back",
                 weeklyTitle: "Week",
                 monthlyTitle: "Month",
+                weeklyProgressTitle: "Weekly Progress",
+                monthlyHistoryTitle: "Monthly History",
+                monthlyHistoryEmptyText: "Empty",
+                monthlyHistoryInProgressText: "In progress",
                 currentSessionGoalLabelPrefix: "Target"
             )
         )

--- a/WorkPulseTests/MainPopoverViewControllerTests.swift
+++ b/WorkPulseTests/MainPopoverViewControllerTests.swift
@@ -561,8 +561,13 @@ struct MainPopoverViewStateFactoryTests {
             startTimeTitle: "In",
             endTimeTitle: "Out",
             deleteActionTitle: "Delete",
+            backActionTitle: "Back",
             weeklyTitle: "Week",
             monthlyTitle: "Month",
+            weeklyProgressTitle: "Weekly Progress",
+            monthlyHistoryTitle: "Monthly History",
+            monthlyHistoryEmptyText: "Empty",
+            monthlyHistoryInProgressText: "In progress",
             currentSessionGoalLabelPrefix: "Goal:"
         )
         let state = MainPopoverViewStateFactory(copy: copy).makePlaceholder()


### PR DESCRIPTION
## 요약
- 메인 팝오버의 `This Week`를 같은 popover 안의 주간 상세 화면으로 연결
- 메인 팝오버의 `This Month`를 별도 월간 히스토리 창으로 연결
- 주간/월간 상세 loader와 navigation 회귀 테스트 추가

## 검증
- `make verify-architecture`
- `xcodebuild -project WorkPulse.xcodeproj -scheme WorkPulse -destination 'platform=macOS' -derivedDataPath /tmp/WorkPulseDD50 -only-testing:WorkPulseTests/MainPopoverDetailNavigationTests -only-testing:WorkPulseTests/MainPopoverSectionViewsTests -only-testing:WorkPulseTests/MainPopoverViewControllerTests -only-testing:WorkPulseTests/MainPopoverRenderModelFactoryTests test`
- `xcodebuild -project WorkPulse.xcodeproj -scheme WorkPulse -destination 'platform=macOS' -derivedDataPath /tmp/WorkPulseDD51 test`
- `make verify`