### PR TITLE
기능: 휴가일 지정을 지원한다

### DIFF
--- a/App/MainPopoverCoordinator.swift
+++ b/App/MainPopoverCoordinator.swift
@@ -101,15 +101,20 @@ final class MainPopoverCoordinator {
     ) {
         self.popoverViewController = popoverViewController
         displayedReferenceDate = referenceDate
-        popoverViewController.onApplyEditedTimes = { [weak self] startTime, endTime in
-            self?.handleAppliedTodayTimes(startTime: startTime, endTime: endTime)
+        popoverViewController.onApplyEditedTimes = { [weak self] startTime, endTime, isVacation in
+            self?.handleAppliedTodayTimes(
+                startTime: startTime,
+                endTime: endTime,
+                isVacation: isVacation
+            )
         }
-        popoverViewController.onApplyEditedDetailTimes = { [weak self] surface, referenceDate, startTime, endTime in
+        popoverViewController.onApplyEditedDetailTimes = { [weak self] surface, referenceDate, startTime, endTime, isVacation in
             self?.handleAppliedDetailTimes(
                 surface: surface,
                 referenceDate: referenceDate,
                 startTime: startTime,
-                endTime: endTime
+                endTime: endTime,
+                isVacation: isVacation
             )
         }
         popoverViewController.onOpenWeeklyProgress = { [weak self] in
@@ -154,20 +159,19 @@ final class MainPopoverCoordinator {
         popoverViewController?.stopCurrentSessionUpdates()
     }
 
-    func applyEditedTimes(startTime: Date?, endTime: Date?) {
-        handleAppliedTodayTimes(startTime: startTime, endTime: endTime)
+    func applyEditedTimes(startTime: Date?, endTime: Date?, isVacation: Bool = false) {
+        handleAppliedTodayTimes(startTime: startTime, endTime: endTime, isVacation: isVacation)
     }
 
-    private func handleAppliedTodayTimes(startTime: Date?, endTime: Date?) {
+    private func handleAppliedTodayTimes(startTime: Date?, endTime: Date?, isVacation: Bool) {
         let referenceDate = currentReferenceDateForPopoverOpen()
         logGeometryEvent("handleAppliedTodayTimes", referenceDate: referenceDate)
         do {
-            try recordStore.upsertRecord(
-                AttendanceRecord(
-                    date: referenceDate,
-                    startTime: startTime,
-                    endTime: endTime
-                )
+            try persistAttendanceRecord(
+                referenceDate: referenceDate,
+                startTime: startTime,
+                endTime: endTime,
+                isVacation: isVacation
             )
         } catch {
             NSLog("Failed to save attendance record: %@", String(describing: error))
@@ -199,6 +203,7 @@ final class MainPopoverCoordinator {
                 viewState: loadedState.viewState,
                 startTime: loadedState.todayRecord?.startTime,
                 endTime: loadedState.todayRecord?.endTime,
+                isVacation: loadedState.todayRecord?.isVacation ?? false,
                 allowsLiveCurrentSessionUpdates: runtimeDependencies.calendar.isDate(
                     referenceDate,
                     inSameDayAs: currentDate
@@ -281,16 +286,16 @@ final class MainPopoverCoordinator {
         surface: MainPopoverDetailSurface,
         referenceDate: Date,
         startTime: Date?,
-        endTime: Date?
+        endTime: Date?,
+        isVacation: Bool
     ) {
         logGeometryEvent("handleAppliedDetailTimes[\(surface)]", referenceDate: referenceDate)
         do {
-            try recordStore.upsertRecord(
-                AttendanceRecord(
-                    date: referenceDate,
-                    startTime: startTime,
-                    endTime: endTime
-                )
+            try persistAttendanceRecord(
+                referenceDate: referenceDate,
+                startTime: startTime,
+                endTime: endTime,
+                isVacation: isVacation
             )
         } catch {
             NSLog("Failed to save detail attendance record: %@", String(describing: error))
@@ -348,8 +353,30 @@ final class MainPopoverCoordinator {
             endTimeText: loadedState.viewState.endTimeText,
             startTime: loadedState.todayRecord?.startTime,
             endTime: loadedState.todayRecord?.endTime,
+            isVacation: loadedState.todayRecord?.isVacation ?? false,
             fallbackStartTime: loadedState.todayRecord?.startTime ?? fallbackStartTime,
             fallbackEndTime: loadedState.todayRecord?.endTime ?? fallbackEndTime
+        )
+    }
+
+    private func persistAttendanceRecord(
+        referenceDate: Date,
+        startTime: Date?,
+        endTime: Date?,
+        isVacation: Bool
+    ) throws {
+        if isVacation == false, startTime == nil, endTime == nil {
+            try recordStore.deleteRecord(on: referenceDate, calendar: runtimeDependencies.calendar)
+            return
+        }
+
+        try recordStore.upsertRecord(
+            AttendanceRecord(
+                date: referenceDate,
+                startTime: startTime,
+                endTime: endTime,
+                isVacation: isVacation
+            )
         )
     }
 

--- a/App/MainPopoverCoordinator.swift
+++ b/App/MainPopoverCoordinator.swift
@@ -342,6 +342,8 @@ final class MainPopoverCoordinator {
 
     private func makeDetailDayEditingState(referenceDate: Date) -> MainPopoverDetailDayEditingState {
         let loadedState = stateLoader.load(referenceDate: referenceDate)
+        let currentDayStart = runtimeDependencies.calendar.startOfDay(for: runtimeDependencies.currentDateProvider())
+        let referenceDayStart = runtimeDependencies.calendar.startOfDay(for: referenceDate)
         let fallbackStartTime = fallbackTime(on: referenceDate, hour: 9, minute: 0)
         let fallbackEndTime = loadedState.todayRecord?.startTime
             ?? fallbackTime(on: referenceDate, hour: 18, minute: 0)
@@ -354,6 +356,7 @@ final class MainPopoverCoordinator {
             startTime: loadedState.todayRecord?.startTime,
             endTime: loadedState.todayRecord?.endTime,
             isVacation: loadedState.todayRecord?.isVacation ?? false,
+            allowsTimeEditing: referenceDayStart <= currentDayStart,
             fallbackStartTime: loadedState.todayRecord?.startTime ?? fallbackStartTime,
             fallbackEndTime: loadedState.todayRecord?.endTime ?? fallbackEndTime
         )

--- a/App/MenuBarShellController.swift
+++ b/App/MenuBarShellController.swift
@@ -156,6 +156,8 @@ final class MenuBarShellController: NSObject {
             return .systemBlue
         case .checkedOut:
             return .systemGreen
+        case .vacation:
+            return .systemTeal
         }
     }
 
@@ -167,6 +169,8 @@ final class MenuBarShellController: NSObject {
             return "업무 중"
         case .checkedOut:
             return "퇴근"
+        case .vacation:
+            return "휴가"
         }
     }
 }

--- a/Feature/MainPopover/Presentation/AttendanceRecord.swift
+++ b/Feature/MainPopover/Presentation/AttendanceRecord.swift
@@ -4,4 +4,40 @@ struct AttendanceRecord: Codable, Equatable {
     let date: Date
     let startTime: Date?
     let endTime: Date?
+    let isVacation: Bool
+
+    init(
+        date: Date,
+        startTime: Date?,
+        endTime: Date?,
+        isVacation: Bool = false
+    ) {
+        self.date = date
+        self.startTime = startTime
+        self.endTime = endTime
+        self.isVacation = isVacation
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case date
+        case startTime
+        case endTime
+        case isVacation
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        date = try container.decode(Date.self, forKey: .date)
+        startTime = try container.decodeIfPresent(Date.self, forKey: .startTime)
+        endTime = try container.decodeIfPresent(Date.self, forKey: .endTime)
+        isVacation = try container.decodeIfPresent(Bool.self, forKey: .isVacation) ?? false
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(startTime, forKey: .startTime)
+        try container.encodeIfPresent(endTime, forKey: .endTime)
+        try container.encode(isVacation, forKey: .isVacation)
+    }
 }

--- a/Feature/MainPopover/Presentation/MainPopoverCopy.swift
+++ b/Feature/MainPopover/Presentation/MainPopoverCopy.swift
@@ -5,6 +5,7 @@ struct MainPopoverCopy {
     let notCheckedInSummaryText: String
     let checkedInSummaryPrefix: String
     let checkedOutSummaryPrefix: String
+    let vacationSummaryText: String
     let currentSessionPlaceholderText: String
     let timePlaceholderText: String
     let totalPlaceholderText: String
@@ -13,9 +14,11 @@ struct MainPopoverCopy {
     let currentSessionWarningTitle: String
     let workedTodayTitle: String
     let workedTodayWarningTitle: String
+    let currentSessionVacationTitle: String
     let currentSessionLeadingCaption: String
     let startTimeTitle: String
     let endTimeTitle: String
+    let vacationToggleTitle: String
     let deleteActionTitle: String
     let backActionTitle: String
     let reportActionTitle: String
@@ -34,6 +37,8 @@ struct MainPopoverCopy {
     let monthlyHistoryOffText: String
     let monthlyHistoryHolidayText: String
     let monthlyHistoryActiveText: String
+    let monthlyHistoryVacationText: String
+    let weeklyVacationText: String
     let currentSessionGoalLabelPrefix: String
 
     static let english = MainPopoverCopy(
@@ -41,6 +46,7 @@ struct MainPopoverCopy {
         notCheckedInSummaryText: "Not checked in yet",
         checkedInSummaryPrefix: "Checked in at",
         checkedOutSummaryPrefix: "Checked out at",
+        vacationSummaryText: "Vacation day",
         currentSessionPlaceholderText: "--:--:--",
         timePlaceholderText: "--:--",
         totalPlaceholderText: "--",
@@ -49,9 +55,11 @@ struct MainPopoverCopy {
         currentSessionWarningTitle: "🔥 CURRENT SESSION",
         workedTodayTitle: "WORKED TODAY",
         workedTodayWarningTitle: "🔥 WORKED TODAY",
+        currentSessionVacationTitle: "VACATION DAY",
         currentSessionLeadingCaption: "0H",
         startTimeTitle: "Start Time",
         endTimeTitle: "End Time",
+        vacationToggleTitle: "Vacation Day",
         deleteActionTitle: "Delete",
         backActionTitle: "Back",
         reportActionTitle: "Report",
@@ -70,6 +78,8 @@ struct MainPopoverCopy {
         monthlyHistoryOffText: "Off",
         monthlyHistoryHolidayText: "Holiday",
         monthlyHistoryActiveText: "Active",
+        monthlyHistoryVacationText: "Vacation",
+        weeklyVacationText: "Vacation",
         currentSessionGoalLabelPrefix: "Goal:"
     )
 

--- a/Feature/MainPopover/Presentation/MainPopoverCopy.swift
+++ b/Feature/MainPopover/Presentation/MainPopoverCopy.swift
@@ -28,6 +28,7 @@ struct MainPopoverCopy {
     let weeklyProgressTitle: String
     let weeklyProgressSegmentTitle: String
     let weeklyQuitTimeSegmentTitle: String
+    let weeklyGoalMetStatusText: String
     let weeklyTodayGoalMetText: String
     let weeklyTodayStatusUnavailableText: String
     let monthlyHistoryTitle: String
@@ -69,6 +70,7 @@ struct MainPopoverCopy {
         weeklyProgressTitle: "Weekly Progress",
         weeklyProgressSegmentTitle: "Progress",
         weeklyQuitTimeSegmentTitle: "Quit Time",
+        weeklyGoalMetStatusText: "On track",
         weeklyTodayGoalMetText: "Through today: On track",
         weeklyTodayStatusUnavailableText: "Through today: Unavailable",
         monthlyHistoryTitle: "MONTHLY HISTORY",

--- a/Feature/MainPopover/Presentation/MainPopoverRenderModelFactory.swift
+++ b/Feature/MainPopover/Presentation/MainPopoverRenderModelFactory.swift
@@ -27,16 +27,57 @@ struct MainPopoverTimeRowRenderModel {
     let isValueVisible: Bool
     let isPickerVisible: Bool
     let pickerDateValue: Date
+    let isEnabled: Bool
+
+    init(
+        titleText: String,
+        valueText: String,
+        isValueVisible: Bool,
+        isPickerVisible: Bool,
+        pickerDateValue: Date,
+        isEnabled: Bool = true
+    ) {
+        self.titleText = titleText
+        self.valueText = valueText
+        self.isValueVisible = isValueVisible
+        self.isPickerVisible = isPickerVisible
+        self.pickerDateValue = pickerDateValue
+        self.isEnabled = isEnabled
+    }
 }
 
 struct MainPopoverTodayTimesRenderModel {
     let startRow: MainPopoverTimeRowRenderModel
     let endRow: MainPopoverTimeRowRenderModel
+    let vacationToggleTitle: String
+    let isVacationSelected: Bool
     let showsEditingActions: Bool
     let showsStartActions: Bool
     let showsEndActions: Bool
     let showsEndDeleteAction: Bool
     let isApplyEnabled: Bool
+
+    init(
+        startRow: MainPopoverTimeRowRenderModel,
+        endRow: MainPopoverTimeRowRenderModel,
+        vacationToggleTitle: String = MainPopoverCopy.english.vacationToggleTitle,
+        isVacationSelected: Bool = false,
+        showsEditingActions: Bool,
+        showsStartActions: Bool,
+        showsEndActions: Bool,
+        showsEndDeleteAction: Bool,
+        isApplyEnabled: Bool
+    ) {
+        self.startRow = startRow
+        self.endRow = endRow
+        self.vacationToggleTitle = vacationToggleTitle
+        self.isVacationSelected = isVacationSelected
+        self.showsEditingActions = showsEditingActions
+        self.showsStartActions = showsStartActions
+        self.showsEndActions = showsEndActions
+        self.showsEndDeleteAction = showsEndDeleteAction
+        self.isApplyEnabled = isApplyEnabled
+    }
 }
 
 struct MainPopoverSummaryItemRenderModel {

--- a/Feature/MainPopover/Presentation/MainPopoverViewStateFactory.swift
+++ b/Feature/MainPopover/Presentation/MainPopoverViewStateFactory.swift
@@ -67,7 +67,7 @@ struct MainPopoverViewStateFactory {
             return copy.notCheckedInSummaryText
         }
 
-        switch MainPopoverAttendanceState.make(startTime: record.startTime, endTime: record.endTime) {
+        switch MainPopoverAttendanceState.make(record: record) {
         case .checkedOut:
             guard let endTime = record.endTime else {
                 return copy.notCheckedInSummaryText
@@ -78,14 +78,15 @@ struct MainPopoverViewStateFactory {
                 return copy.notCheckedInSummaryText
             }
             return copy.checkedInSummaryText(for: timeFormatter.string(from: startTime))
+        case .vacation:
+            return copy.vacationSummaryText
         case .notCheckedIn:
             return copy.notCheckedInSummaryText
         }
     }
 
     private func attendanceState(for record: AttendanceRecord?) -> MainPopoverAttendanceState {
-        guard let record else { return .notCheckedIn }
-        return MainPopoverAttendanceState.make(startTime: record.startTime, endTime: record.endTime)
+        MainPopoverAttendanceState.make(record: record)
     }
 
     private func timeText(for date: Date?) -> String {

--- a/Feature/MainPopover/Presentation/TodayTimeEditModeState.swift
+++ b/Feature/MainPopover/Presentation/TodayTimeEditModeState.swift
@@ -3,8 +3,10 @@ import Foundation
 struct TodayTimeEditModeState {
     private(set) var savedStartTime: Date?
     private(set) var savedEndTime: Date?
+    private(set) var savedIsVacation = false
     private(set) var draftStartTime: Date?
     private(set) var draftEndTime: Date?
+    private(set) var draftIsVacation = false
     private(set) var editingField: TodayTimeField?
 
     var isEditingStartTime: Bool {
@@ -16,6 +18,10 @@ struct TodayTimeEditModeState {
     }
 
     var hasValidDraftTimes: Bool {
+        if draftIsVacation {
+            return true
+        }
+
         guard let draftStartTime else {
             return draftEndTime == nil
         }
@@ -27,20 +33,28 @@ struct TodayTimeEditModeState {
         return draftEndTime >= draftStartTime
     }
 
-    mutating func loadSavedTimes(startTime: Date?, endTime: Date?) {
+    var isVacationSelected: Bool {
+        draftIsVacation
+    }
+
+    mutating func loadSavedTimes(startTime: Date?, endTime: Date?, isVacation: Bool = false) {
         savedStartTime = startTime
         savedEndTime = endTime
+        savedIsVacation = isVacation
 
         guard editingField == nil else { return }
 
         draftStartTime = startTime
         draftEndTime = endTime
+        draftIsVacation = isVacation
     }
 
     mutating func beginEditing(_ field: TodayTimeField) {
+        guard savedIsVacation == false else { return }
         editingField = field
         draftStartTime = savedStartTime
         draftEndTime = savedEndTime
+        draftIsVacation = savedIsVacation
     }
 
     mutating func updateDraftStartTime(_ startTime: Date) {
@@ -54,8 +68,14 @@ struct TodayTimeEditModeState {
     mutating func apply() -> (startTime: Date?, endTime: Date?)? {
         guard editingField != nil else { return nil }
 
-        savedStartTime = draftStartTime
-        savedEndTime = draftEndTime
+        if draftIsVacation {
+            savedStartTime = nil
+            savedEndTime = nil
+        } else {
+            savedStartTime = draftStartTime
+            savedEndTime = draftEndTime
+        }
+        savedIsVacation = draftIsVacation
         editingField = nil
 
         return (savedStartTime, savedEndTime)
@@ -67,13 +87,31 @@ struct TodayTimeEditModeState {
         savedEndTime = nil
         draftEndTime = nil
         editingField = nil
+        savedIsVacation = false
+        draftIsVacation = false
 
         return (savedStartTime, nil)
+    }
+
+    mutating func setVacation(_ isVacation: Bool) -> (startTime: Date?, endTime: Date?) {
+        savedIsVacation = isVacation
+        draftIsVacation = isVacation
+        editingField = nil
+
+        if isVacation {
+            savedStartTime = nil
+            savedEndTime = nil
+            draftStartTime = nil
+            draftEndTime = nil
+        }
+
+        return (savedStartTime, savedEndTime)
     }
 
     mutating func cancel() {
         draftStartTime = savedStartTime
         draftEndTime = savedEndTime
+        draftIsVacation = savedIsVacation
         editingField = nil
     }
 }

--- a/Feature/MainPopover/Repo/AttendanceRecordStore.swift
+++ b/Feature/MainPopover/Repo/AttendanceRecordStore.swift
@@ -139,11 +139,12 @@ final class SwiftDataAttendanceRecordStore: AttendanceRecordStore {
     }
 
     func deleteRecord(on date: Date, calendar: Calendar) throws {
-        guard let entity = loadAllEntities().last(where: { calendar.isDate($0.date, inSameDayAs: date) }) else {
+        let matchingEntities = loadAllEntities().filter { calendar.isDate($0.date, inSameDayAs: date) }
+        guard matchingEntities.isEmpty == false else {
             return
         }
 
-        modelContext.delete(entity)
+        matchingEntities.forEach(modelContext.delete)
         try saveContext()
     }
 

--- a/Feature/MainPopover/Repo/AttendanceRecordStore.swift
+++ b/Feature/MainPopover/Repo/AttendanceRecordStore.swift
@@ -8,6 +8,7 @@ protocol AttendanceRecordQuerying {
 
 protocol AttendanceRecordWriting {
     func upsertRecord(_ record: AttendanceRecord) throws
+    func deleteRecord(on date: Date, calendar: Calendar) throws
 }
 
 protocol AttendanceRecordStore: AttendanceRecordQuerying, AttendanceRecordWriting {}
@@ -45,6 +46,11 @@ struct MirroredAttendanceRecordStore: AttendanceRecordStore {
         try primary.upsertRecord(record)
         try fallback.upsertRecord(record)
     }
+
+    func deleteRecord(on date: Date, calendar: Calendar) throws {
+        try primary.deleteRecord(on: date, calendar: calendar)
+        try fallback.deleteRecord(on: date, calendar: calendar)
+    }
 }
 
 @Model
@@ -52,18 +58,21 @@ final class AttendanceRecordEntity {
     var date: Date
     var startTime: Date?
     var endTime: Date?
+    var isVacation: Bool
 
-    init(date: Date, startTime: Date?, endTime: Date?) {
+    init(date: Date, startTime: Date?, endTime: Date?, isVacation: Bool = false) {
         self.date = date
         self.startTime = startTime
         self.endTime = endTime
+        self.isVacation = isVacation
     }
 
     convenience init(record: AttendanceRecord) {
         self.init(
             date: record.date,
             startTime: record.startTime,
-            endTime: record.endTime
+            endTime: record.endTime,
+            isVacation: record.isVacation
         )
     }
 
@@ -71,7 +80,8 @@ final class AttendanceRecordEntity {
         AttendanceRecord(
             date: date,
             startTime: startTime,
-            endTime: endTime
+            endTime: endTime,
+            isVacation: isVacation
         )
     }
 }
@@ -120,10 +130,20 @@ final class SwiftDataAttendanceRecordStore: AttendanceRecordStore {
             entity.date = record.date
             entity.startTime = record.startTime
             entity.endTime = record.endTime
+            entity.isVacation = record.isVacation
         } else {
             modelContext.insert(AttendanceRecordEntity(record: record))
         }
 
+        try saveContext()
+    }
+
+    func deleteRecord(on date: Date, calendar: Calendar) throws {
+        guard let entity = loadAllEntities().last(where: { calendar.isDate($0.date, inSameDayAs: date) }) else {
+            return
+        }
+
+        modelContext.delete(entity)
         try saveContext()
     }
 
@@ -205,6 +225,15 @@ struct UserDefaultsAttendanceRecordStore: AttendanceRecordStore {
             records[index] = record
         } else {
             records.append(record)
+        }
+
+        let data = try encoder.encode(records)
+        userDefaults.set(data, forKey: key)
+    }
+
+    func deleteRecord(on date: Date, calendar: Calendar) throws {
+        let records = loadAllRecords().filter {
+            calendar.isDate($0.date, inSameDayAs: date) == false
         }
 
         let data = try encoder.encode(records)

--- a/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
+++ b/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
@@ -351,8 +351,8 @@ struct MainPopoverWeeklyProgressLoader {
     }
 
     private func progressFraction(for duration: TimeInterval, goalDuration: TimeInterval) -> CGFloat {
-        guard duration > 0 else { return 0 }
         guard goalDuration > 0 else { return 1 }
+        guard duration > 0 else { return 0 }
         if duration >= goalDuration {
             return 1
         }

--- a/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
+++ b/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
@@ -101,7 +101,6 @@ struct MainPopoverWeeklyProgressLoader {
     private let calendarDayMetadataProvider: any CalendarDayMetadataProviding
     private let currentDateProvider: () -> Date
     private let copy: MainPopoverCopy
-    private let goalDuration: TimeInterval
     private let quitTimeInsightCalculator: QuitTimeInsightCalculator
     private let dayFormatter: DateFormatter
     private let timeFormatter: DateFormatter
@@ -122,7 +121,6 @@ struct MainPopoverWeeklyProgressLoader {
             ?? KoreanCalendarDayMetadataProvider(timeZone: timeZone)
         self.currentDateProvider = currentDateProvider
         self.copy = copy
-        self.goalDuration = 40 * 60 * 60
         self.quitTimeInsightCalculator = QuitTimeInsightCalculator(calendar: calendar)
 
         let dayFormatter = DateFormatter()
@@ -170,7 +168,8 @@ struct MainPopoverWeeklyProgressLoader {
                     isToday: calendar.isDate(date, inSameDayAs: referenceDate),
                     isSelectable: true
                 ),
-                duration
+                duration,
+                record
             )
         }
         let totalDuration = dayStatesWithDuration
@@ -178,9 +177,12 @@ struct MainPopoverWeeklyProgressLoader {
                 entry.1
             }
             .reduce(0, +)
-        let progressFraction = progressFraction(for: totalDuration)
+        let weekGoalDuration = dayStatesWithDuration.reduce(0 as TimeInterval) { partialResult, entry in
+            partialResult + goalDuration(for: entry.0.date, record: entry.2)
+        }
+        let progressFraction = progressFraction(for: totalDuration, goalDuration: weekGoalDuration)
         let weekOfYear = calendar.component(.weekOfYear, from: referenceDate)
-        let visualState: MainPopoverCurrentSessionVisualState = totalDuration > goalDuration
+        let visualState: MainPopoverCurrentSessionVisualState = totalDuration > weekGoalDuration
             ? .warning
             : .normal
         let selectedRecord = recordStore.record(on: referenceDate, calendar: calendar)
@@ -189,7 +191,11 @@ struct MainPopoverWeeklyProgressLoader {
             titleText: copy.weeklyProgressTitle,
             weekText: copy.weeklyLabelText(weekOfYear: weekOfYear),
             totalDurationText: formatTotalDuration(totalDuration),
-            statusText: statusText(for: totalDuration, visualState: visualState),
+            statusText: statusText(
+                for: totalDuration,
+                goalDuration: weekGoalDuration,
+                visualState: visualState
+            ),
             quitTimeStatusText: quitTimeStatusText(
                 for: selectedRecord,
                 referenceDate: referenceDate,
@@ -261,10 +267,14 @@ struct MainPopoverWeeklyProgressLoader {
 
     private func statusText(
         for totalDuration: TimeInterval,
+        goalDuration: TimeInterval,
         visualState: MainPopoverCurrentSessionVisualState
     ) -> String {
         switch visualState {
         case .normal:
+            guard goalDuration > 0 else {
+                return copy.weeklyGoalMetStatusText
+            }
             let remainingDuration = max(0, goalDuration - totalDuration)
             return copy.weeklyRemainingStatusText(
                 durationText: formatStatusDuration(remainingDuration),
@@ -340,8 +350,9 @@ struct MainPopoverWeeklyProgressLoader {
         return min(1, max(0, fraction))
     }
 
-    private func progressFraction(for duration: TimeInterval) -> CGFloat {
+    private func progressFraction(for duration: TimeInterval, goalDuration: TimeInterval) -> CGFloat {
         guard duration > 0 else { return 0 }
+        guard goalDuration > 0 else { return 1 }
         if duration >= goalDuration {
             return 1
         }

--- a/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
+++ b/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
@@ -9,6 +9,7 @@ struct MainPopoverWeeklyProgressDayViewState {
     let quitDeltaText: String
     let annotationText: String?
     let dayCategory: CalendarDayCategory
+    let isVacation: Bool
     let isOvertime: Bool
     let progressFraction: CGFloat
     let isToday: Bool
@@ -22,6 +23,7 @@ struct MainPopoverWeeklyProgressDayViewState {
         quitDeltaText: String? = nil,
         annotationText: String?,
         dayCategory: CalendarDayCategory,
+        isVacation: Bool = false,
         isOvertime: Bool = false,
         progressFraction: CGFloat,
         isToday: Bool,
@@ -34,6 +36,7 @@ struct MainPopoverWeeklyProgressDayViewState {
         self.quitDeltaText = quitDeltaText ?? workedText
         self.annotationText = annotationText
         self.dayCategory = dayCategory
+        self.isVacation = isVacation
         self.isOvertime = isOvertime
         self.progressFraction = progressFraction
         self.isToday = isToday
@@ -158,10 +161,11 @@ struct MainPopoverWeeklyProgressLoader {
                     date: date,
                     dayText: dayFormatter.string(from: date),
                     timeRangeText: makeTimeRangeText(record: record),
-                    workedText: formatWorkedDuration(duration),
-                    quitDeltaText: quitDeltaText(for: duration),
-                    annotationText: metadata.holiday?.annotationText,
+                    workedText: workedText(for: record, duration: duration),
+                    quitDeltaText: quitDeltaText(for: record, duration: duration),
+                    annotationText: annotationText(for: record, metadata: metadata),
                     dayCategory: metadata.category,
+                    isVacation: record?.isVacation ?? false,
                     isOvertime: isOvertime(duration),
                     progressFraction: dailyProgressFraction(for: duration),
                     isToday: calendar.isDate(date, inSameDayAs: referenceDate),
@@ -212,7 +216,21 @@ struct MainPopoverWeeklyProgressLoader {
     }
 
     private func makeTimeRangeText(record: AttendanceRecord?) -> String {
-        "\(formatTime(record?.startTime)) - \(formatTime(record?.endTime))"
+        if record?.isVacation == true {
+            return copy.weeklyVacationText
+        }
+        return "\(formatTime(record?.startTime)) - \(formatTime(record?.endTime))"
+    }
+
+    private func annotationText(
+        for record: AttendanceRecord?,
+        metadata: CalendarDayMetadata
+    ) -> String? {
+        if record?.isVacation == true {
+            return copy.weeklyVacationText
+        }
+
+        return metadata.holiday?.annotationText
     }
 
     private func formatTime(_ date: Date?) -> String {
@@ -278,7 +296,19 @@ struct MainPopoverWeeklyProgressLoader {
         return String(format: "%02d:%02d", hours, minutes)
     }
 
-    private func quitDeltaText(for duration: TimeInterval?) -> String {
+    private func workedText(for record: AttendanceRecord?, duration: TimeInterval?) -> String {
+        if record?.isVacation == true {
+            return copy.weeklyVacationText
+        }
+
+        return formatWorkedDuration(duration)
+    }
+
+    private func quitDeltaText(for record: AttendanceRecord?, duration: TimeInterval?) -> String {
+        if record?.isVacation == true {
+            return copy.totalPlaceholderText
+        }
+
         guard let duration else {
             return copy.totalPlaceholderText
         }
@@ -332,6 +362,8 @@ struct MainPopoverWeeklyProgressLoader {
         switch quitTimeInsightCalculator.make(record: record) {
         case .noRecord:
             return copy.weeklyNoCheckInStatusText
+        case .vacation:
+            return copy.weeklyVacationText
         case .invalidRecord:
             return copy.weeklyQuitTimeUnavailableText
         case let .available(_, earliestQuitTime, checkoutTime):
@@ -398,10 +430,15 @@ struct MainPopoverWeeklyProgressLoader {
         var delta: TimeInterval = 0
 
         for date in priorDates {
-            let dailyGoalDuration = goalDuration(for: date)
+            let record = recordStore.record(on: date, calendar: calendar)
+            let dailyGoalDuration = goalDuration(for: date, record: record)
             delta -= dailyGoalDuration
 
-            guard let record = recordStore.record(on: date, calendar: calendar) else {
+            guard let record else {
+                continue
+            }
+
+            if record.isVacation {
                 continue
             }
 
@@ -420,6 +457,10 @@ struct MainPopoverWeeklyProgressLoader {
             return deltaState(for: delta)
         }
 
+        if todayRecord.isVacation {
+            return deltaState(for: delta)
+        }
+
         guard let todayDuration = workedDuration(
             for: todayRecord,
             referenceDate: todayDate,
@@ -428,7 +469,7 @@ struct MainPopoverWeeklyProgressLoader {
             return .unavailable
         }
 
-        let todayGoalDuration = goalDuration(for: todayDate)
+        let todayGoalDuration = goalDuration(for: todayDate, record: todayRecord)
         if todayRecord.endTime != nil {
             delta += todayDuration - todayGoalDuration
         } else if todayGoalDuration == 0 {
@@ -440,8 +481,12 @@ struct MainPopoverWeeklyProgressLoader {
         return deltaState(for: delta)
     }
 
-    private func goalDuration(for date: Date) -> TimeInterval {
-        calendarDayMetadataProvider.metadata(for: date).category == .weekday
+    private func goalDuration(for date: Date, record: AttendanceRecord? = nil) -> TimeInterval {
+        guard record?.isVacation != true else {
+            return 0
+        }
+
+        return calendarDayMetadataProvider.metadata(for: date).category == .weekday
             ? MainPopoverCurrentSessionProgressPolicy.defaultGoalDuration
             : 0
     }

--- a/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
+++ b/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
@@ -146,7 +146,6 @@ struct MainPopoverWeeklyProgressLoader {
 
     func load(referenceDate: Date, currentDate: Date) -> MainPopoverWeeklyProgressViewState {
         let weekDates = makeWeekDates(for: referenceDate)
-        let currentDayStart = calendar.startOfDay(for: currentDate)
         let dayStatesWithDuration = weekDates.map { date in
             let record = recordStore.record(on: date, calendar: calendar)
             let metadata = calendarDayMetadataProvider.metadata(for: date)
@@ -169,7 +168,7 @@ struct MainPopoverWeeklyProgressLoader {
                     isOvertime: isOvertime(duration),
                     progressFraction: dailyProgressFraction(for: duration),
                     isToday: calendar.isDate(date, inSameDayAs: referenceDate),
-                    isSelectable: calendar.startOfDay(for: date) <= currentDayStart
+                    isSelectable: true
                 ),
                 duration
             )

--- a/Feature/MainPopover/Service/MonthlyHistoryLoader.swift
+++ b/Feature/MainPopover/Service/MonthlyHistoryLoader.swift
@@ -186,7 +186,7 @@ struct MonthlyHistoryLoader {
                     dayCategory: metadata.category,
                     isOvertime: isOvertime,
                     isDimmed: isFuture,
-                    isSelectable: isFuture == false
+                    isSelectable: true
                 )
             )
         }

--- a/Feature/MainPopover/Service/MonthlyHistoryLoader.swift
+++ b/Feature/MainPopover/Service/MonthlyHistoryLoader.swift
@@ -5,6 +5,7 @@ enum MonthlyHistoryDayCellActivity: Equatable {
     case empty
     case worked
     case active
+    case vacation
 }
 
 struct MonthlyHistoryDayCellViewState: Equatable {
@@ -161,7 +162,10 @@ struct MonthlyHistoryLoader {
             let activity: MonthlyHistoryDayCellActivity
             let cellStatusText: String
 
-            if isToday, record?.startTime != nil, record?.endTime == nil {
+            if record?.isVacation == true {
+                activity = .vacation
+                cellStatusText = copy.monthlyHistoryVacationText
+            } else if isToday, record?.startTime != nil, record?.endTime == nil {
                 activity = .active
                 cellStatusText = copy.monthlyHistoryActiveText
             } else if let workedDuration, workedDuration > 0 {

--- a/Feature/MainPopover/Service/QuitTimeInsightCalculator.swift
+++ b/Feature/MainPopover/Service/QuitTimeInsightCalculator.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum QuitTimeInsight {
     case noRecord
+    case vacation
     case invalidRecord(startTime: Date?)
     case available(startTime: Date, earliestQuitTime: Date, checkoutTime: Date?)
 }
@@ -20,6 +21,9 @@ struct QuitTimeInsightCalculator {
 
     func make(record: AttendanceRecord?) -> QuitTimeInsight {
         guard let record else { return .noRecord }
+        if record.isVacation {
+            return .vacation
+        }
         guard let startTime = record.startTime else { return .invalidRecord(startTime: nil) }
 
         let earliestQuitTime = earliestQuitTime(for: startTime)

--- a/Feature/MainPopover/Service/TodayQuitReportBuilder.swift
+++ b/Feature/MainPopover/Service/TodayQuitReportBuilder.swift
@@ -41,6 +41,14 @@ struct TodayQuitReportBuilder {
                 checkoutTimeText: nil,
                 throughTodayStatusText: throughTodayStatusText
             )
+        case .vacation:
+            return report(
+                startTimeText: "휴가",
+                earliestQuitTimeText: "해당 없음",
+                statusText: "휴가",
+                checkoutTimeText: nil,
+                throughTodayStatusText: throughTodayStatusText
+            )
         case let .invalidRecord(startTime):
             return report(
                 startTimeText: startTime.map { timeFormatter.string(from: $0) } ?? "기록 이상",

--- a/UI/MainPopover/MainPopoverCurrentSessionBinder.swift
+++ b/UI/MainPopover/MainPopoverCurrentSessionBinder.swift
@@ -53,8 +53,26 @@ final class MainPopoverCurrentSessionBinder {
         runtime.apply(startTime: startTime, endTime: endTime)
     }
 
+    func apply(startTime: Date?, endTime: Date?, isVacation: Bool) {
+        attendanceState = MainPopoverAttendanceState.make(
+            startTime: startTime,
+            endTime: endTime,
+            isVacation: isVacation
+        )
+        runtime.apply(startTime: startTime, endTime: endTime)
+    }
+
     func begin(startTime: Date?, endTime: Date?) {
         attendanceState = MainPopoverAttendanceState.make(startTime: startTime, endTime: endTime)
+        runtime.begin(startTime: startTime, endTime: endTime)
+    }
+
+    func begin(startTime: Date?, endTime: Date?, isVacation: Bool) {
+        attendanceState = MainPopoverAttendanceState.make(
+            startTime: startTime,
+            endTime: endTime,
+            isVacation: isVacation
+        )
         runtime.begin(startTime: startTime, endTime: endTime)
     }
 
@@ -90,6 +108,8 @@ final class MainPopoverCurrentSessionBinder {
             return isWarningState ? copy.currentSessionWarningTitle : copy.currentSessionTitle
         case .checkedOut:
             return isWarningState ? copy.workedTodayWarningTitle : copy.workedTodayTitle
+        case .vacation:
+            return copy.currentSessionVacationTitle
         }
     }
 

--- a/UI/MainPopover/MainPopoverStyle.swift
+++ b/UI/MainPopover/MainPopoverStyle.swift
@@ -89,6 +89,9 @@ enum MainPopoverStyle {
         static var weekendAccent: NSColor { .systemTeal }
         static var holidayAccent: NSColor { .systemRed }
         static var substituteHolidayAccent: NSColor { .systemOrange }
+        static var vacationAccent: NSColor { .systemIndigo }
+        static var vacationBackground: NSColor { .systemIndigo.withAlphaComponent(0.10) }
+        static var vacationBorder: NSColor { .systemIndigo.withAlphaComponent(0.18) }
         static var progressTrackBackground: NSColor { .secondarySystemFill }
         static var progressTrackBorder: NSColor { .separatorColor }
         static var weeklyProgressTrackBackground: NSColor { .black.withAlphaComponent(0.05) }

--- a/UI/MainPopover/MainPopoverTodayTimesBinder.swift
+++ b/UI/MainPopover/MainPopoverTodayTimesBinder.swift
@@ -22,6 +22,7 @@ final class MainPopoverTodayTimesBinder {
     private let sectionView: MainPopoverTodayTimesSectionView
     private let copy: MainPopoverCopy
     private var editModeState = TodayTimeEditModeState()
+    private var allowsTimeEditing = true
 
     var onDidChange: (() -> Void)?
     var onDidApplyTimes: ((MainPopoverAppliedTodayTimes) -> Void)?
@@ -40,15 +41,18 @@ final class MainPopoverTodayTimesBinder {
         startTime: Date?,
         endTime: Date?,
         isVacation: Bool = false,
+        allowsTimeEditing: Bool = true,
         forceReload: Bool = false
     ) {
         if forceReload {
             editModeState = TodayTimeEditModeState()
         }
+        self.allowsTimeEditing = allowsTimeEditing
         editModeState.loadSavedTimes(startTime: startTime, endTime: endTime, isVacation: isVacation)
     }
 
     func beginEditing(_ field: TodayTimeField) {
+        guard allowsTimeEditing else { return }
         editModeState.beginEditing(field)
         onDidChange?()
     }
@@ -190,7 +194,7 @@ final class MainPopoverTodayTimesBinder {
             isValueVisible: !isEditing,
             isPickerVisible: isEditing,
             pickerDateValue: draftTime ?? fallbackTime,
-            isEnabled: editModeState.isVacationSelected == false
+            isEnabled: allowsTimeEditing && editModeState.isVacationSelected == false
         )
     }
 }

--- a/UI/MainPopover/MainPopoverTodayTimesBinder.swift
+++ b/UI/MainPopover/MainPopoverTodayTimesBinder.swift
@@ -8,6 +8,13 @@ struct MainPopoverTodayTimesDisplayState {
 struct MainPopoverAppliedTodayTimes {
     let startTime: Date?
     let endTime: Date?
+    let isVacation: Bool
+
+    init(startTime: Date?, endTime: Date?, isVacation: Bool = false) {
+        self.startTime = startTime
+        self.endTime = endTime
+        self.isVacation = isVacation
+    }
 }
 
 @MainActor
@@ -29,11 +36,16 @@ final class MainPopoverTodayTimesBinder {
         bindSectionEvents()
     }
 
-    func loadSavedTimes(startTime: Date?, endTime: Date?, forceReload: Bool = false) {
+    func loadSavedTimes(
+        startTime: Date?,
+        endTime: Date?,
+        isVacation: Bool = false,
+        forceReload: Bool = false
+    ) {
         if forceReload {
             editModeState = TodayTimeEditModeState()
         }
-        editModeState.loadSavedTimes(startTime: startTime, endTime: endTime)
+        editModeState.loadSavedTimes(startTime: startTime, endTime: endTime, isVacation: isVacation)
     }
 
     func beginEditing(_ field: TodayTimeField) {
@@ -67,7 +79,8 @@ final class MainPopoverTodayTimesBinder {
         onDidApplyTimes?(
             MainPopoverAppliedTodayTimes(
                 startTime: appliedTimes.startTime,
-                endTime: appliedTimes.endTime
+                endTime: appliedTimes.endTime,
+                isVacation: editModeState.isVacationSelected
             )
         )
         onDidChange?()
@@ -79,7 +92,20 @@ final class MainPopoverTodayTimesBinder {
         onDidApplyTimes?(
             MainPopoverAppliedTodayTimes(
                 startTime: appliedTimes.startTime,
-                endTime: appliedTimes.endTime
+                endTime: appliedTimes.endTime,
+                isVacation: false
+            )
+        )
+        onDidChange?()
+    }
+
+    func setVacation(_ isVacation: Bool) {
+        let appliedTimes = editModeState.setVacation(isVacation)
+        onDidApplyTimes?(
+            MainPopoverAppliedTodayTimes(
+                startTime: appliedTimes.startTime,
+                endTime: appliedTimes.endTime,
+                isVacation: isVacation
             )
         )
         onDidChange?()
@@ -109,6 +135,8 @@ final class MainPopoverTodayTimesBinder {
                 draftTime: editModeState.draftEndTime,
                 fallbackTime: fallbackEndTime
             ),
+            vacationToggleTitle: copy.vacationToggleTitle,
+            isVacationSelected: editModeState.isVacationSelected,
             showsEditingActions: editModeState.editingField != nil,
             showsStartActions: editModeState.isEditingStartTime,
             showsEndActions: editModeState.isEditingEndTime,
@@ -128,6 +156,8 @@ final class MainPopoverTodayTimesBinder {
                 self?.cancelEditing()
             case .deleteEndTime:
                 self?.deleteEndTime()
+            case .toggleVacation(let isVacation):
+                self?.setVacation(isVacation)
             case .draftChanged(let draft):
                 self?.updateDraft(draft)
             }
@@ -159,7 +189,8 @@ final class MainPopoverTodayTimesBinder {
             valueText: valueText,
             isValueVisible: !isEditing,
             isPickerVisible: isEditing,
-            pickerDateValue: draftTime ?? fallbackTime
+            pickerDateValue: draftTime ?? fallbackTime,
+            isEnabled: editModeState.isVacationSelected == false
         )
     }
 }

--- a/UI/MainPopover/MainPopoverTodayTimesSectionView.swift
+++ b/UI/MainPopover/MainPopoverTodayTimesSectionView.swift
@@ -6,6 +6,7 @@ struct MainPopoverTimeRowSnapshot {
     let isValueVisible: Bool
     let isPickerVisible: Bool
     let pickerDateValue: Date
+    let isEnabled: Bool
 }
 
 struct MainPopoverTodayTimesDraft {
@@ -59,7 +60,8 @@ final class MainPopoverTimeRowView: NSView {
             valueText: valueLabel.stringValue,
             isValueVisible: valueLabel.isHidden == false,
             isPickerVisible: picker.isHidden == false,
-            pickerDateValue: picker.dateValue
+            pickerDateValue: picker.dateValue,
+            isEnabled: picker.isEnabled
         )
     }
 
@@ -213,6 +215,7 @@ final class MainPopoverTodayTimesSectionView: NSView {
     )
     private let editingActionRow = NSStackView()
     private var isVacationSelected = false
+    private var allowsTimeRowInteraction = true
 
     var onEvent: ((MainPopoverTodayTimesSectionEvent) -> Void)?
 
@@ -228,6 +231,7 @@ final class MainPopoverTodayTimesSectionView: NSView {
 
     func apply(_ renderModel: MainPopoverTodayTimesRenderModel) {
         isVacationSelected = renderModel.isVacationSelected
+        allowsTimeRowInteraction = renderModel.startRow.isEnabled || renderModel.endRow.isEnabled
         vacationToggleButton.title = renderModel.vacationToggleTitle
         vacationToggleButton.state = renderModel.isVacationSelected ? .on : .off
         startRowView.apply(renderModel.startRow)
@@ -360,13 +364,13 @@ final class MainPopoverTodayTimesSectionView: NSView {
 
     @objc
     private func handleStartRowTap() {
-        guard isVacationSelected == false else { return }
+        guard isVacationSelected == false, allowsTimeRowInteraction else { return }
         onEvent?(.beginEditing(.startTime))
     }
 
     @objc
     private func handleEndRowTap() {
-        guard isVacationSelected == false else { return }
+        guard isVacationSelected == false, allowsTimeRowInteraction else { return }
         onEvent?(.beginEditing(.endTime))
     }
 
@@ -445,6 +449,7 @@ final class MainPopoverDetailDayEditorView: NSView {
             startTime: editingState.startTime,
             endTime: editingState.endTime,
             isVacation: editingState.isVacation,
+            allowsTimeEditing: editingState.allowsTimeEditing,
             forceReload: true
         )
         render()

--- a/UI/MainPopover/MainPopoverTodayTimesSectionView.swift
+++ b/UI/MainPopover/MainPopoverTodayTimesSectionView.swift
@@ -36,6 +36,8 @@ final class MainPopoverTimeRowView: NSView {
         valueLabel.stringValue = renderModel.valueText
         valueLabel.isHidden = !renderModel.isValueVisible
         picker.isHidden = !renderModel.isPickerVisible
+        picker.isEnabled = renderModel.isEnabled
+        alphaValue = renderModel.isEnabled ? 1 : 0.55
         if renderModel.isPickerVisible == false {
             isPickerTextEditing = false
         }
@@ -174,6 +176,7 @@ final class MainPopoverTimeRowView: NSView {
 struct MainPopoverTodayTimesSectionSnapshot {
     let startRow: MainPopoverTimeRowSnapshot
     let endRow: MainPopoverTimeRowSnapshot
+    let isVacationSelected: Bool
     let isStartApplyVisible: Bool
     let isStartCancelVisible: Bool
     let isEndApplyVisible: Bool
@@ -189,12 +192,14 @@ enum MainPopoverTodayTimesSectionEvent {
     case applyEditing
     case cancelEditing
     case deleteEndTime
+    case toggleVacation(Bool)
     case draftChanged(MainPopoverTodayTimesDraft)
 }
 
 final class MainPopoverTodayTimesSectionView: NSView {
     private let startRowView = MainPopoverTimeRowView(iconSystemName: "arrow.right.to.line")
     private let endRowView = MainPopoverTimeRowView(iconSystemName: "rectangle.portrait.and.arrow.right")
+    private let vacationToggleButton = NSButton(checkboxWithTitle: "", target: nil, action: nil)
     private let startTimeApplyButton = NSButton(title: "Apply", target: nil, action: nil)
     private let startTimeCancelButton = NSButton(title: "Cancel", target: nil, action: nil)
     private let endTimeApplyButton = NSButton(title: "Apply", target: nil, action: nil)
@@ -207,6 +212,7 @@ final class MainPopoverTodayTimesSectionView: NSView {
         shadow: true
     )
     private let editingActionRow = NSStackView()
+    private var isVacationSelected = false
 
     var onEvent: ((MainPopoverTodayTimesSectionEvent) -> Void)?
 
@@ -221,8 +227,13 @@ final class MainPopoverTodayTimesSectionView: NSView {
     }
 
     func apply(_ renderModel: MainPopoverTodayTimesRenderModel) {
+        isVacationSelected = renderModel.isVacationSelected
+        vacationToggleButton.title = renderModel.vacationToggleTitle
+        vacationToggleButton.state = renderModel.isVacationSelected ? .on : .off
         startRowView.apply(renderModel.startRow)
         endRowView.apply(renderModel.endRow)
+        startRowView.alphaValue = renderModel.startRow.isEnabled ? 1 : 0.55
+        endRowView.alphaValue = renderModel.endRow.isEnabled ? 1 : 0.55
 
         editingActionRow.isHidden = !renderModel.showsEditingActions
         startTimeApplyButton.isHidden = !renderModel.showsStartActions
@@ -255,6 +266,7 @@ final class MainPopoverTodayTimesSectionView: NSView {
         return MainPopoverTodayTimesSectionSnapshot(
             startRow: startRowView.snapshot,
             endRow: endRowView.snapshot,
+            isVacationSelected: vacationToggleButton.state == .on,
             isStartApplyVisible: startTimeApplyButton.isHidden == false,
             isStartCancelVisible: startTimeCancelButton.isHidden == false,
             isEndApplyVisible: endTimeApplyButton.isHidden == false,
@@ -280,6 +292,12 @@ final class MainPopoverTodayTimesSectionView: NSView {
         container.translatesAutoresizingMaskIntoConstraints = false
         container.contentStack.spacing = MainPopoverStyle.Metrics.todayTimesSpacing
 
+        vacationToggleButton.setButtonType(.switch)
+        vacationToggleButton.controlSize = .small
+        vacationToggleButton.font = .systemFont(ofSize: 11, weight: .semibold)
+        vacationToggleButton.target = self
+        vacationToggleButton.action = #selector(handleToggleVacation)
+
         [startTimeApplyButton, startTimeCancelButton, endTimeApplyButton, endTimeCancelButton, endTimeDeleteButton].forEach { button in
             button.bezelStyle = .rounded
             button.controlSize = .small
@@ -302,6 +320,7 @@ final class MainPopoverTodayTimesSectionView: NSView {
         editingActionRow.addArrangedSubview(endTimeApplyButton)
         editingActionRow.isHidden = true
 
+        container.contentStack.addArrangedSubview(vacationToggleButton)
         container.contentStack.addArrangedSubview(startRowView)
         container.contentStack.addArrangedSubview(endRowView)
         container.contentStack.addArrangedSubview(editingActionRow)
@@ -341,11 +360,13 @@ final class MainPopoverTodayTimesSectionView: NSView {
 
     @objc
     private func handleStartRowTap() {
+        guard isVacationSelected == false else { return }
         onEvent?(.beginEditing(.startTime))
     }
 
     @objc
     private func handleEndRowTap() {
+        guard isVacationSelected == false else { return }
         onEvent?(.beginEditing(.endTime))
     }
 
@@ -362,6 +383,12 @@ final class MainPopoverTodayTimesSectionView: NSView {
     @objc
     private func handleDeleteEndTime() {
         onEvent?(.deleteEndTime)
+    }
+
+    @objc
+    private func handleToggleVacation() {
+        isVacationSelected = vacationToggleButton.state == .on
+        onEvent?(.toggleVacation(isVacationSelected))
     }
 
 }
@@ -384,7 +411,7 @@ final class MainPopoverDetailDayEditorView: NSView {
     private lazy var collapsedHeightConstraint = heightAnchor.constraint(equalToConstant: 0)
     private var editingState: MainPopoverDetailDayEditingState?
 
-    var onApplyEditedTimes: ((Date, Date?, Date?) -> Void)?
+    var onApplyEditedTimes: ((Date, Date?, Date?, Bool) -> Void)?
 
     override init(frame frameRect: NSRect) {
         self.binder = MainPopoverTodayTimesBinder(sectionView: todayTimesSectionView)
@@ -417,6 +444,7 @@ final class MainPopoverDetailDayEditorView: NSView {
         binder.loadSavedTimes(
             startTime: editingState.startTime,
             endTime: editingState.endTime,
+            isVacation: editingState.isVacation,
             forceReload: true
         )
         render()
@@ -476,7 +504,8 @@ final class MainPopoverDetailDayEditorView: NSView {
             self.onApplyEditedTimes?(
                 editingState.referenceDate,
                 appliedTimes.startTime,
-                appliedTimes.endTime
+                appliedTimes.endTime,
+                appliedTimes.isVacation
             )
         }
     }

--- a/UI/MainPopover/MainPopoverViewController.swift
+++ b/UI/MainPopover/MainPopoverViewController.swift
@@ -32,8 +32,8 @@ final class MainPopoverViewController: NSViewController {
     private let currentSessionCalculator: CurrentSessionCalculator
     private let currentSessionScheduler: any CurrentSessionScheduling
     private let renderModelFactory: MainPopoverRenderModelFactory
-    var onApplyEditedTimes: ((Date?, Date?) -> Void)?
-    var onApplyEditedDetailTimes: ((MainPopoverDetailSurface, Date, Date?, Date?) -> Void)?
+    var onApplyEditedTimes: ((Date?, Date?, Bool) -> Void)?
+    var onApplyEditedDetailTimes: ((MainPopoverDetailSurface, Date, Date?, Date?, Bool) -> Void)?
     var onOpenWeeklyProgress: (() -> Void)?
     var onOpenMonthlyHistory: (() -> Void)?
     var onSelectDetailDate: ((MainPopoverDetailSurface, Date) -> Void)?
@@ -77,7 +77,7 @@ final class MainPopoverViewController: NSViewController {
             self?.render()
         }
         binder.onDidApplyTimes = { [weak self] appliedTimes in
-            self?.onApplyEditedTimes?(appliedTimes.startTime, appliedTimes.endTime)
+            self?.onApplyEditedTimes?(appliedTimes.startTime, appliedTimes.endTime, appliedTimes.isVacation)
         }
         return binder
     }()
@@ -113,8 +113,8 @@ final class MainPopoverViewController: NSViewController {
         weeklyDetailSectionView.onSelectDay = { [weak self] selectedDate in
             self?.onSelectDetailDate?(.weekly, selectedDate)
         }
-        weeklyDetailSectionView.onApplyEditedDayTimes = { [weak self] date, startTime, endTime in
-            self?.onApplyEditedDetailTimes?(.weekly, date, startTime, endTime)
+        weeklyDetailSectionView.onApplyEditedDayTimes = { [weak self] date, startTime, endTime, isVacation in
+            self?.onApplyEditedDetailTimes?(.weekly, date, startTime, endTime, isVacation)
         }
         monthlyHistoryViewController.onNavigatePrevious = { [weak self] in
             self?.onNavigateMonthlyHistory?(-1)
@@ -125,8 +125,8 @@ final class MainPopoverViewController: NSViewController {
         monthlyHistoryViewController.onSelectDay = { [weak self] selectedDate in
             self?.onSelectDetailDate?(.monthly, selectedDate)
         }
-        monthlyHistoryViewController.onApplyEditedDayTimes = { [weak self] date, startTime, endTime in
-            self?.onApplyEditedDetailTimes?(.monthly, date, startTime, endTime)
+        monthlyHistoryViewController.onApplyEditedDayTimes = { [weak self] date, startTime, endTime, isVacation in
+            self?.onApplyEditedDetailTimes?(.monthly, date, startTime, endTime, isVacation)
         }
     }
 
@@ -216,14 +216,33 @@ final class MainPopoverViewController: NSViewController {
 
     func display(_ intent: MainPopoverDisplayIntent) {
         state = intent.viewState
-        todayTimesBinder.loadSavedTimes(startTime: intent.startTime, endTime: intent.endTime)
+        todayTimesBinder.loadSavedTimes(
+            startTime: intent.startTime,
+            endTime: intent.endTime,
+            isVacation: intent.isVacation
+        )
         currentSessionBinder.load(viewState: intent.viewState)
 
-        if intent.allowsLiveCurrentSessionUpdates {
-            currentSessionBinder.begin(startTime: intent.startTime, endTime: intent.endTime)
+        if intent.isVacation {
+            currentSessionBinder.stop()
+            currentSessionBinder.apply(
+                startTime: intent.startTime,
+                endTime: intent.endTime,
+                isVacation: true
+            )
+        } else if intent.allowsLiveCurrentSessionUpdates {
+            currentSessionBinder.begin(
+                startTime: intent.startTime,
+                endTime: intent.endTime,
+                isVacation: false
+            )
         } else if intent.endTime != nil {
             currentSessionBinder.stop()
-            currentSessionBinder.apply(startTime: intent.startTime, endTime: intent.endTime)
+            currentSessionBinder.apply(
+                startTime: intent.startTime,
+                endTime: intent.endTime,
+                isVacation: false
+            )
         } else {
             currentSessionBinder.stop()
         }
@@ -236,7 +255,7 @@ final class MainPopoverViewController: NSViewController {
     }
 
     func beginCurrentSessionUpdates(startTime: Date?, endTime: Date?) {
-        todayTimesBinder.loadSavedTimes(startTime: startTime, endTime: endTime)
+        todayTimesBinder.loadSavedTimes(startTime: startTime, endTime: endTime, isVacation: false)
         currentSessionBinder.begin(startTime: startTime, endTime: endTime)
         render()
     }

--- a/UI/MainPopover/MainPopoverViewState.swift
+++ b/UI/MainPopover/MainPopoverViewState.swift
@@ -9,8 +9,25 @@ enum MainPopoverAttendanceState: Equatable {
     case notCheckedIn
     case checkedIn
     case checkedOut
+    case vacation
 
-    static func make(startTime: Date?, endTime: Date?) -> Self {
+    static func make(record: AttendanceRecord?) -> Self {
+        guard let record else {
+            return .notCheckedIn
+        }
+
+        return make(
+            startTime: record.startTime,
+            endTime: record.endTime,
+            isVacation: record.isVacation
+        )
+    }
+
+    static func make(startTime: Date?, endTime: Date?, isVacation: Bool = false) -> Self {
+        if isVacation {
+            return .vacation
+        }
+
         guard let startTime else {
             return .notCheckedIn
         }
@@ -30,15 +47,53 @@ struct MainPopoverDetailDayEditingState {
     let endTimeText: String
     let startTime: Date?
     let endTime: Date?
+    let isVacation: Bool
     let fallbackStartTime: Date
     let fallbackEndTime: Date
+
+    init(
+        referenceDate: Date,
+        dateText: String,
+        startTimeText: String,
+        endTimeText: String,
+        startTime: Date?,
+        endTime: Date?,
+        isVacation: Bool = false,
+        fallbackStartTime: Date,
+        fallbackEndTime: Date
+    ) {
+        self.referenceDate = referenceDate
+        self.dateText = dateText
+        self.startTimeText = startTimeText
+        self.endTimeText = endTimeText
+        self.startTime = startTime
+        self.endTime = endTime
+        self.isVacation = isVacation
+        self.fallbackStartTime = fallbackStartTime
+        self.fallbackEndTime = fallbackEndTime
+    }
 }
 
 struct MainPopoverDisplayIntent {
     let viewState: MainPopoverViewState
     let startTime: Date?
     let endTime: Date?
+    let isVacation: Bool
     let allowsLiveCurrentSessionUpdates: Bool
+
+    init(
+        viewState: MainPopoverViewState,
+        startTime: Date?,
+        endTime: Date?,
+        isVacation: Bool = false,
+        allowsLiveCurrentSessionUpdates: Bool
+    ) {
+        self.viewState = viewState
+        self.startTime = startTime
+        self.endTime = endTime
+        self.isVacation = isVacation
+        self.allowsLiveCurrentSessionUpdates = allowsLiveCurrentSessionUpdates
+    }
 }
 
 struct MainPopoverViewState {

--- a/UI/MainPopover/MainPopoverViewState.swift
+++ b/UI/MainPopover/MainPopoverViewState.swift
@@ -48,6 +48,7 @@ struct MainPopoverDetailDayEditingState {
     let startTime: Date?
     let endTime: Date?
     let isVacation: Bool
+    let allowsTimeEditing: Bool
     let fallbackStartTime: Date
     let fallbackEndTime: Date
 
@@ -59,6 +60,7 @@ struct MainPopoverDetailDayEditingState {
         startTime: Date?,
         endTime: Date?,
         isVacation: Bool = false,
+        allowsTimeEditing: Bool = true,
         fallbackStartTime: Date,
         fallbackEndTime: Date
     ) {
@@ -69,6 +71,7 @@ struct MainPopoverDetailDayEditingState {
         self.startTime = startTime
         self.endTime = endTime
         self.isVacation = isVacation
+        self.allowsTimeEditing = allowsTimeEditing
         self.fallbackStartTime = fallbackStartTime
         self.fallbackEndTime = fallbackEndTime
     }

--- a/UI/MainPopover/MainPopoverWeeklyProgressSectionView.swift
+++ b/UI/MainPopover/MainPopoverWeeklyProgressSectionView.swift
@@ -35,6 +35,7 @@ private final class MainPopoverWeeklyProgressDayRowView: NSView {
     private var selectedDate: Date?
     private var isSelectable = false
     private var isOvertime = false
+    private var isVacation = false
     private var currentState: MainPopoverWeeklyProgressDayViewState?
     private var displayMode: MainPopoverWeeklyProgressStatusSegment = .progress
     var onSelect: ((Date) -> Void)?
@@ -109,9 +110,12 @@ private final class MainPopoverWeeklyProgressDayRowView: NSView {
         annotationLabel.isHidden = state.annotationText == nil
         progressBar.progressFraction = state.progressFraction
         isOvertime = state.isOvertime
+        isVacation = state.isVacation
         progressBar.applyVisualState(state.isOvertime ? .warning : .normal)
 
-        let accentColor = state.isOvertime
+        let accentColor = state.isVacation
+            ? MainPopoverStyle.Colors.vacationAccent
+            : state.isOvertime
             ? MainPopoverStyle.Colors.detailOvertimeAccent
             : accentColor(for: state.dayCategory)
         dayLabel.font = .systemFont(
@@ -209,7 +213,7 @@ final class MainPopoverWeeklyProgressSectionView: NSView {
 
     var onBack: (() -> Void)?
     var onSelectDay: ((Date) -> Void)?
-    var onApplyEditedDayTimes: ((Date, Date?, Date?) -> Void)?
+    var onApplyEditedDayTimes: ((Date, Date?, Date?, Bool) -> Void)?
     private let copy: MainPopoverCopy
 
     private let backButton = NSButton(title: "", target: nil, action: nil)
@@ -455,8 +459,8 @@ final class MainPopoverWeeklyProgressSectionView: NSView {
         rowsStack.setContentHuggingPriority(.required, for: .vertical)
         rowsStack.setContentCompressionResistancePriority(.required, for: .vertical)
 
-        detailEditorView.onApplyEditedTimes = { [weak self] date, startTime, endTime in
-            self?.onApplyEditedDayTimes?(date, startTime, endTime)
+        detailEditorView.onApplyEditedTimes = { [weak self] date, startTime, endTime, isVacation in
+            self?.onApplyEditedDayTimes?(date, startTime, endTime, isVacation)
         }
 
         addSubview(backButton)

--- a/UI/MonthlyHistory/MonthlyHistoryViewController.swift
+++ b/UI/MonthlyHistory/MonthlyHistoryViewController.swift
@@ -94,6 +94,9 @@ private final class MonthlyHistoryDayCellView: NSView {
         case .active:
             applyActivePalette(for: state.dayCategory, isOvertime: state.isOvertime)
             alphaValue = state.isDimmed ? 0.55 : 1
+        case .vacation:
+            applyVacationPalette()
+            alphaValue = state.isDimmed ? 0.55 : 1
         case .empty:
             applyEmptyPalette(for: state.dayCategory)
             alphaValue = state.isDimmed ? 0.55 : 0.78
@@ -108,6 +111,9 @@ private final class MonthlyHistoryDayCellView: NSView {
             dayLabel.font = .systemFont(ofSize: 10, weight: .semibold)
             statusLabel.font = .systemFont(ofSize: 9, weight: .bold)
         case .active:
+            dayLabel.font = .systemFont(ofSize: 10, weight: .bold)
+            statusLabel.font = .systemFont(ofSize: 9, weight: .bold)
+        case .vacation:
             dayLabel.font = .systemFont(ofSize: 10, weight: .bold)
             statusLabel.font = .systemFont(ofSize: 9, weight: .bold)
         case .empty:
@@ -177,6 +183,13 @@ private final class MonthlyHistoryDayCellView: NSView {
         }
     }
 
+    private func applyVacationPalette() {
+        layer?.backgroundColor = MainPopoverStyle.Colors.vacationBackground.cgColor
+        layer?.borderColor = MainPopoverStyle.Colors.vacationBorder.cgColor
+        dayLabel.textColor = MainPopoverStyle.Colors.vacationAccent
+        statusLabel.textColor = MainPopoverStyle.Colors.vacationAccent
+    }
+
     private func accentColor(for category: CalendarDayCategory) -> NSColor? {
         switch category {
         case .weekday:
@@ -200,6 +213,10 @@ private final class MonthlyHistoryDayCellView: NSView {
 
     var isActive: Bool {
         activity == .active
+    }
+
+    var isVacationState: Bool {
+        activity == .vacation
     }
 
     var isOvertimeState: Bool {
@@ -248,7 +265,7 @@ final class MonthlyHistoryViewController: NSViewController {
     var onNavigatePrevious: (() -> Void)?
     var onNavigateNext: (() -> Void)?
     var onSelectDay: ((Date) -> Void)?
-    var onApplyEditedDayTimes: ((Date, Date?, Date?) -> Void)?
+    var onApplyEditedDayTimes: ((Date, Date?, Date?, Bool) -> Void)?
 
     private let previousButton = NSButton(title: "", target: nil, action: nil)
     private let nextButton = NSButton(title: "", target: nil, action: nil)
@@ -381,8 +398,8 @@ final class MonthlyHistoryViewController: NSViewController {
 
         footerView.addSubview(footerRow)
 
-        detailEditorView.onApplyEditedTimes = { [weak self] date, startTime, endTime in
-            self?.onApplyEditedDayTimes?(date, startTime, endTime)
+        detailEditorView.onApplyEditedTimes = { [weak self] date, startTime, endTime, isVacation in
+            self?.onApplyEditedDayTimes?(date, startTime, endTime, isVacation)
         }
 
         rootView.addSubview(headerView)

--- a/WorkPulseTests/CurrentSessionCalculatorTests.swift
+++ b/WorkPulseTests/CurrentSessionCalculatorTests.swift
@@ -701,6 +701,30 @@ struct SwiftDataAttendanceRecordStoreTests {
         #expect(store.loadRecords() == [legacyRecord])
     }
 
+    @Test
+    func deleteRecordRemovesAllSameDayRows() throws {
+        let duplicateDate = try #require(ISO8601DateFormatter().date(from: "2026-03-31T00:00:00+09:00"))
+        let firstRecord = AttendanceRecord(
+            date: duplicateDate,
+            startTime: try #require(ISO8601DateFormatter().date(from: "2026-03-31T09:00:00+09:00")),
+            endTime: nil
+        )
+        let duplicateRecord = AttendanceRecord(
+            date: duplicateDate,
+            startTime: try #require(ISO8601DateFormatter().date(from: "2026-03-31T08:30:00+09:00")),
+            endTime: try #require(ISO8601DateFormatter().date(from: "2026-03-31T18:00:00+09:00"))
+        )
+        let store = try SwiftDataAttendanceRecordStore(
+            calendar: Self.seoulCalendar,
+            legacyRecords: [firstRecord, duplicateRecord]
+        )
+
+        try store.deleteRecord(on: duplicateDate, calendar: Self.seoulCalendar)
+
+        #expect(store.record(on: duplicateDate, calendar: Self.seoulCalendar) == nil)
+        #expect(store.loadRecords().isEmpty)
+    }
+
     private func makeStore() throws -> SwiftDataAttendanceRecordStore {
         let configuration = ModelConfiguration(
             for: AttendanceRecordEntity.self,

--- a/WorkPulseTests/CurrentSessionCalculatorTests.swift
+++ b/WorkPulseTests/CurrentSessionCalculatorTests.swift
@@ -1723,6 +1723,27 @@ struct TodayTimeEditModeStateTests {
 
         #expect(state.hasValidDraftTimes == false)
     }
+
+    @Test
+    func selectingVacationClearsTimesAndMakesDraftValid() throws {
+        let startTime = try #require(
+            ISO8601DateFormatter().date(from: "2026-03-31T09:00:00+09:00")
+        )
+        let endTime = try #require(
+            ISO8601DateFormatter().date(from: "2026-03-31T18:00:00+09:00")
+        )
+        var state = TodayTimeEditModeState()
+        state.loadSavedTimes(startTime: startTime, endTime: endTime)
+
+        let appliedTimes = state.setVacation(true)
+
+        #expect(appliedTimes.startTime == nil)
+        #expect(appliedTimes.endTime == nil)
+        #expect(state.savedStartTime == nil)
+        #expect(state.savedEndTime == nil)
+        #expect(state.isVacationSelected)
+        #expect(state.hasValidDraftTimes)
+    }
 }
 
 private final class InMemoryAttendanceRecordStore: AttendanceRecordStore {
@@ -1756,6 +1777,10 @@ private final class InMemoryAttendanceRecordStore: AttendanceRecordStore {
 
         records.append(record)
     }
+
+    func deleteRecord(on date: Date, calendar: Calendar) throws {
+        records.removeAll { calendar.isDate($0.date, inSameDayAs: date) }
+    }
 }
 
 private struct ThrowingAttendanceRecordStore: AttendanceRecordStore {
@@ -1778,6 +1803,10 @@ private struct ThrowingAttendanceRecordStore: AttendanceRecordStore {
     }
 
     func upsertRecord(_ record: AttendanceRecord) throws {
+        throw TestError.saveFailed
+    }
+
+    func deleteRecord(on date: Date, calendar: Calendar) throws {
         throw TestError.saveFailed
     }
 }

--- a/WorkPulseTests/MainPopoverDetailNavigationTests.swift
+++ b/WorkPulseTests/MainPopoverDetailNavigationTests.swift
@@ -1089,6 +1089,8 @@ struct MainPopoverDetailLoadersTests {
         #expect(mondayState.timeRangeText == "Vacation")
         #expect(mondayState.workedText == "Vacation")
         #expect(mondayState.annotationText == "Vacation")
+        #expect(state.statusText == "32h 00m remaining to 32h")
+        #expect(state.progressFraction == 0)
         #expect(state.todayDeltaStatusText == "Through today: On track")
     }
 

--- a/WorkPulseTests/MainPopoverDetailNavigationTests.swift
+++ b/WorkPulseTests/MainPopoverDetailNavigationTests.swift
@@ -998,6 +998,26 @@ struct MainPopoverDetailLoadersTests {
     }
 
     @Test
+    func monthlyHistoryLoaderAllowsSelectingFutureDaysForVacationPlanning() throws {
+        let currentDate = try #require(
+            makeDate("2026-04-02T12:00:00+09:00")
+        )
+        let loader = MonthlyHistoryLoader(
+            recordStore: DetailTestAttendanceRecordStore(records: []),
+            calendar: makeSeoulCalendar(),
+            locale: Locale(identifier: "en_US_POSIX"),
+            timeZone: TimeZone(identifier: "Asia/Seoul")!,
+            currentDateProvider: { currentDate }
+        )
+
+        let state = loader.load(referenceDate: currentDate)
+        let futureCell = try #require(state.cells.first(where: { $0.dayText == "3" }))
+
+        #expect(futureCell.isDimmed)
+        #expect(futureCell.isSelectable)
+    }
+
+    @Test
     func weeklyProgressLoaderAnnotatesHolidayRowsWithoutChangingTotals() throws {
         let referenceDate = try #require(
             makeDate("2026-03-02T12:00:00+09:00")
@@ -1070,6 +1090,25 @@ struct MainPopoverDetailLoadersTests {
         #expect(mondayState.workedText == "Vacation")
         #expect(mondayState.annotationText == "Vacation")
         #expect(state.todayDeltaStatusText == "Through today: On track")
+    }
+
+    @Test
+    func weeklyProgressLoaderAllowsSelectingFutureDaysForVacationPlanning() throws {
+        let currentDate = try #require(
+            makeDate("2026-04-07T10:00:00+09:00")
+        )
+        let loader = MainPopoverWeeklyProgressLoader(
+            recordStore: DetailTestAttendanceRecordStore(records: []),
+            calendar: makeSeoulCalendar(),
+            locale: Locale(identifier: "en_US_POSIX"),
+            timeZone: TimeZone(identifier: "Asia/Seoul")!,
+            currentDateProvider: { currentDate }
+        )
+
+        let state = loader.load(referenceDate: currentDate, currentDate: currentDate)
+        let futureDay = try #require(state.days.first(where: { $0.dayText == "Wed 8" }))
+
+        #expect(futureDay.isSelectable)
     }
 
     @Test

--- a/WorkPulseTests/MainPopoverDetailNavigationTests.swift
+++ b/WorkPulseTests/MainPopoverDetailNavigationTests.swift
@@ -970,6 +970,34 @@ struct MainPopoverDetailLoadersTests {
     }
 
     @Test
+    func monthlyHistoryLoaderMarksVacationDays() throws {
+        let referenceDate = try #require(
+            makeDate("2026-04-02T12:00:00+09:00")
+        )
+        let store = DetailTestAttendanceRecordStore(records: [
+            AttendanceRecord(
+                date: try #require(makeDate("2026-04-02T00:00:00+09:00")),
+                startTime: nil,
+                endTime: nil,
+                isVacation: true
+            ),
+        ])
+        let loader = MonthlyHistoryLoader(
+            recordStore: store,
+            calendar: makeSeoulCalendar(),
+            locale: Locale(identifier: "en_US_POSIX"),
+            timeZone: TimeZone(identifier: "Asia/Seoul")!,
+            currentDateProvider: { referenceDate }
+        )
+
+        let state = loader.load(referenceDate: referenceDate)
+        let vacationCell = try #require(state.cells.first(where: { $0.dayText == "2" }))
+
+        #expect(vacationCell.activity == .vacation)
+        #expect(vacationCell.statusText == "Vacation")
+    }
+
+    @Test
     func weeklyProgressLoaderAnnotatesHolidayRowsWithoutChangingTotals() throws {
         let referenceDate = try #require(
             makeDate("2026-03-02T12:00:00+09:00")
@@ -1010,6 +1038,38 @@ struct MainPopoverDetailLoadersTests {
         #expect(mondayState.dayCategory == .substituteHoliday)
         #expect(mondayState.annotationText?.contains("대체공휴일") == true)
         #expect(mondayState.annotationText?.contains("3·1절") == true)
+    }
+
+    @Test
+    func weeklyProgressLoaderTreatsVacationWeekdaysAsZeroGoalDays() throws {
+        let currentDate = try #require(
+            makeDate("2026-04-07T10:00:00+09:00")
+        )
+        let vacationDate = try #require(
+            makeDate("2026-04-06T00:00:00+09:00")
+        )
+        let loader = MainPopoverWeeklyProgressLoader(
+            recordStore: DetailTestAttendanceRecordStore(records: [
+                AttendanceRecord(
+                    date: vacationDate,
+                    startTime: nil,
+                    endTime: nil,
+                    isVacation: true
+                ),
+            ]),
+            calendar: makeSeoulCalendar(),
+            locale: Locale(identifier: "en_US_POSIX"),
+            timeZone: TimeZone(identifier: "Asia/Seoul")!,
+            currentDateProvider: { currentDate }
+        )
+
+        let state = loader.load(referenceDate: currentDate, currentDate: currentDate)
+        let mondayState = try #require(state.days.first(where: { $0.dayText == "Mon 6" }))
+
+        #expect(mondayState.timeRangeText == "Vacation")
+        #expect(mondayState.workedText == "Vacation")
+        #expect(mondayState.annotationText == "Vacation")
+        #expect(state.todayDeltaStatusText == "Through today: On track")
     }
 
     @Test
@@ -1178,6 +1238,10 @@ private struct DetailTestAttendanceRecordStore: AttendanceRecordStore {
 
     func upsertRecord(_ record: AttendanceRecord) throws {
         Issue.record("upsertRecord should not be called in detail loader tests")
+    }
+
+    func deleteRecord(on date: Date, calendar: Calendar) throws {
+        Issue.record("deleteRecord should not be called in detail loader tests")
     }
 }
 

--- a/WorkPulseTests/MainPopoverDetailNavigationTests.swift
+++ b/WorkPulseTests/MainPopoverDetailNavigationTests.swift
@@ -1089,8 +1089,8 @@ struct MainPopoverDetailLoadersTests {
         #expect(mondayState.timeRangeText == "Vacation")
         #expect(mondayState.workedText == "Vacation")
         #expect(mondayState.annotationText == "Vacation")
-        #expect(state.statusText == "32h 00m remaining to 32h")
-        #expect(state.progressFraction == 0)
+        #expect(state.statusText == "On track")
+        #expect(state.progressFraction == 1)
         #expect(state.todayDeltaStatusText == "Through today: On track")
     }
 

--- a/WorkPulseTests/MainPopoverRenderModelFactoryTests.swift
+++ b/WorkPulseTests/MainPopoverRenderModelFactoryTests.swift
@@ -59,6 +59,7 @@ struct MainPopoverRenderModelFactoryTests {
                 notCheckedInSummaryText: "Waiting to start",
                 checkedInSummaryPrefix: "Checked in at",
                 checkedOutSummaryPrefix: "Checked out at",
+                vacationSummaryText: "Vacation day",
                 currentSessionPlaceholderText: "--:--:--",
                 timePlaceholderText: "--:--",
                 totalPlaceholderText: "--",
@@ -67,9 +68,11 @@ struct MainPopoverRenderModelFactoryTests {
                 currentSessionWarningTitle: "🔥 SESSION",
                 workedTodayTitle: "DONE",
                 workedTodayWarningTitle: "🔥 DONE",
+                currentSessionVacationTitle: "VACATION",
                 currentSessionLeadingCaption: "START",
                 startTimeTitle: "In",
                 endTimeTitle: "Out",
+                vacationToggleTitle: "Vacation",
                 deleteActionTitle: "Delete",
                 backActionTitle: "Back",
                 reportActionTitle: "Report",
@@ -88,6 +91,8 @@ struct MainPopoverRenderModelFactoryTests {
                 monthlyHistoryOffText: "Off",
                 monthlyHistoryHolidayText: "Holiday",
                 monthlyHistoryActiveText: "Active",
+                monthlyHistoryVacationText: "Vacation",
+                weeklyVacationText: "Vacation",
                 currentSessionGoalLabelPrefix: "Target"
             )
         )

--- a/WorkPulseTests/MainPopoverRenderModelFactoryTests.swift
+++ b/WorkPulseTests/MainPopoverRenderModelFactoryTests.swift
@@ -82,6 +82,7 @@ struct MainPopoverRenderModelFactoryTests {
                 weeklyProgressTitle: "Weekly Progress",
                 weeklyProgressSegmentTitle: "Progress",
                 weeklyQuitTimeSegmentTitle: "Quit Time",
+                weeklyGoalMetStatusText: "On track",
                 weeklyTodayGoalMetText: "Today: Goal met",
                 weeklyTodayStatusUnavailableText: "Today: Unavailable",
                 monthlyHistoryTitle: "Monthly History",

--- a/WorkPulseTests/MainPopoverViewControllerTests.swift
+++ b/WorkPulseTests/MainPopoverViewControllerTests.swift
@@ -615,6 +615,33 @@ struct MainPopoverTodayTimesBinderTests {
         #expect(section.snapshot.isApplyEnabled)
     }
 
+    @Test
+    @MainActor
+    func futureDatesDisableTimeEditingWhileKeepingVacationToggleAvailable() throws {
+        let startTime = try #require(
+            ISO8601DateFormatter().date(from: "2026-03-31T09:00:00+09:00")
+        )
+        let (binder, section) = makeBinderAndSection()
+
+        binder.loadSavedTimes(startTime: startTime, endTime: nil, allowsTimeEditing: false)
+        binder.beginEditing(.startTime)
+        section.sectionView.apply(
+            binder.makeRenderModel(
+                displayState: makeDisplayState(startTimeText: "09:00", endTimeText: "--:--"),
+                fallbackStartTime: startTime,
+                fallbackEndTime: startTime
+            )
+        )
+
+        let snapshot = section.snapshot
+
+        #expect(snapshot.startRow.isEnabled == false)
+        #expect(snapshot.endRow.isEnabled == false)
+        #expect(snapshot.startRow.isPickerVisible == false)
+        #expect(snapshot.isStartApplyVisible == false)
+        #expect(snapshot.isVacationSelected == false)
+    }
+
     @MainActor
     private func makeBinderAndSection() -> (MainPopoverTodayTimesBinder, MainPopoverViewSnapshottingSection) {
         let section = MainPopoverViewSnapshottingSection()

--- a/WorkPulseTests/MainPopoverViewControllerTests.swift
+++ b/WorkPulseTests/MainPopoverViewControllerTests.swift
@@ -728,6 +728,7 @@ struct MainPopoverViewStateFactoryTests {
             weeklyProgressTitle: "Weekly Progress",
             weeklyProgressSegmentTitle: "Progress",
             weeklyQuitTimeSegmentTitle: "Quit Time",
+            weeklyGoalMetStatusText: "On track",
             weeklyTodayGoalMetText: "Today: Goal met",
             weeklyTodayStatusUnavailableText: "Today: Unavailable",
             monthlyHistoryTitle: "Monthly History",

--- a/WorkPulseTests/MainPopoverViewControllerTests.swift
+++ b/WorkPulseTests/MainPopoverViewControllerTests.swift
@@ -678,6 +678,7 @@ struct MainPopoverViewStateFactoryTests {
             notCheckedInSummaryText: "Waiting to start",
             checkedInSummaryPrefix: "Arrived",
             checkedOutSummaryPrefix: "Left at",
+            vacationSummaryText: "Vacation day",
             currentSessionPlaceholderText: "00:00:00",
             timePlaceholderText: "--.--",
             totalPlaceholderText: "n/a",
@@ -686,9 +687,11 @@ struct MainPopoverViewStateFactoryTests {
             currentSessionWarningTitle: "🔥 SESSION",
             workedTodayTitle: "DONE",
             workedTodayWarningTitle: "🔥 DONE",
+            currentSessionVacationTitle: "VACATION",
             currentSessionLeadingCaption: "0H",
             startTimeTitle: "In",
             endTimeTitle: "Out",
+            vacationToggleTitle: "Vacation",
             deleteActionTitle: "Delete",
             backActionTitle: "Back",
             reportActionTitle: "Report",
@@ -707,6 +710,8 @@ struct MainPopoverViewStateFactoryTests {
             monthlyHistoryOffText: "Off",
             monthlyHistoryHolidayText: "Holiday",
             monthlyHistoryActiveText: "Active",
+            monthlyHistoryVacationText: "Vacation",
+            weeklyVacationText: "Vacation",
             currentSessionGoalLabelPrefix: "Goal:"
         )
         let state = MainPopoverViewStateFactory(copy: copy).makePlaceholder()
@@ -839,6 +844,34 @@ struct MainPopoverViewStateFactoryTests {
         #expect(state.startTimeText == "18:30")
         #expect(state.endTimeText == "09:00")
         #expect(state.attendanceState == .checkedIn)
+    }
+
+    @Test
+    func marksVacationRecordsAsVacationState() throws {
+        let factory = MainPopoverViewStateFactory(
+            calendar: Self.seoulCalendar,
+            locale: Locale(identifier: "en_US_POSIX"),
+            timeZone: try #require(TimeZone(secondsFromGMT: 9 * 60 * 60))
+        )
+        let referenceDate = try #require(
+            ISO8601DateFormatter().date(from: "2026-03-31T09:00:00+09:00")
+        )
+        let record = AttendanceRecord(
+            date: referenceDate,
+            startTime: nil,
+            endTime: nil,
+            isVacation: true
+        )
+
+        let state = factory.make(
+            referenceDate: referenceDate,
+            todayRecord: record
+        )
+
+        #expect(state.checkedInSummaryText == "Vacation day")
+        #expect(state.startTimeText == "--:--")
+        #expect(state.endTimeText == "--:--")
+        #expect(state.attendanceState == .vacation)
     }
 
     private static var seoulCalendar: Calendar {

--- a/WorkPulseTests/MenuBarShellControllerTests.swift
+++ b/WorkPulseTests/MenuBarShellControllerTests.swift
@@ -56,6 +56,12 @@ struct MenuBarShellControllerTests {
         #expect(button.toolTip == "퇴근")
         #expect(button.image != nil)
         #expect(button.contentTintColor == nil)
+
+        controller.updateStatusItem(attendanceState: .vacation)
+        #expect(button.title == "")
+        #expect(button.toolTip == "휴가")
+        #expect(button.image != nil)
+        #expect(button.contentTintColor == nil)
     }
 
     @Test

--- a/WorkPulseTests/TodayQuitReportBuilderTests.swift
+++ b/WorkPulseTests/TodayQuitReportBuilderTests.swift
@@ -128,6 +128,39 @@ struct TodayQuitReportBuilderTests {
             """
         )
     }
+
+    @Test
+    func reportsVacationDay() throws {
+        let builder = TodayQuitReportBuilder(
+            calendar: makeSeoulCalendar(),
+            locale: Locale(identifier: "ko_KR"),
+            timeZone: try #require(TimeZone(secondsFromGMT: 9 * 60 * 60))
+        )
+        let now = try #require(
+            ISO8601DateFormatter().date(from: "2026-04-07T10:00:00+09:00")
+        )
+
+        let report = builder.make(
+            todayRecord: AttendanceRecord(
+                date: now,
+                startTime: nil,
+                endTime: nil,
+                isVacation: true
+            ),
+            now: now,
+            throughTodayStatusText: "Through today: On track"
+        )
+
+        #expect(
+            report == """
+            [퇴근 가능 시간 보고]
+            오늘 출근 시간: 휴가
+            오늘 퇴근 가능 시간: 해당 없음
+            현재 상태: 휴가
+            오늘까지 누적 상태: 정상
+            """
+        )
+    }
 }
 
 @Suite("QuitReportCopy")
@@ -251,6 +284,10 @@ private final class InMemoryAttendanceRecordStoreForQuitReport: AttendanceRecord
         } else {
             records.append(record)
         }
+    }
+
+    func deleteRecord(on date: Date, calendar: Calendar) throws {
+        records.removeAll { calendar.isDate($0.date, inSameDayAs: date) }
     }
 }
 


### PR DESCRIPTION
## 요약
- 메인 화면과 주간/월간 상세에서 휴가일 지정 기능을 추가합니다
- 미래 날짜도 휴가일로 계획할 수 있게 허용합니다
- 휴가가 포함된 주의 주간 목표를 고정 40시간이 아니라 실제 기대 근무시간으로 계산합니다

## 상세
- 휴가일은 출근/퇴근 시간과 상호 배타적으로 저장됩니다
- 미래 날짜는 휴가 토글만 허용하고 시간 편집은 막습니다
- 주간 누적/상단 주간 카드 목표는 휴가 평일을 0시간 목표로 반영합니다
- 메뉴바 상태, 월간 상세, 보고서 경로도 휴가 상태를 반영합니다

## 검증
- `xcodebuild -project WorkPulse.xcodeproj -scheme WorkPulse -destination 'platform=macOS' -derivedDataPath /tmp/WorkPulseDD183 test -only-testing:WorkPulseTests/MainPopoverDetailNavigationTests -only-testing:WorkPulseTests/MainPopoverRenderModelFactoryTests -only-testing:WorkPulseTests/MainPopoverViewControllerTests`
- `make verify-architecture`
- `make verify`