### PR TITLE
메인 팝오버 한글화와 시간 기준 정합성 수정

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -9,13 +9,14 @@ struct MainPopoverRuntimeDependencies {
     let currentSessionScheduler: any CurrentSessionScheduling
 
     static var live: MainPopoverRuntimeDependencies {
-        let timeZone = TimeZone.current
+        let timeZone = TimeZone(identifier: "Asia/Seoul") ?? .current
         var calendar = Calendar.current
+        calendar.locale = Locale(identifier: "ko_KR")
         calendar.timeZone = timeZone
 
         return MainPopoverRuntimeDependencies(
             calendar: calendar,
-            locale: .current,
+            locale: Locale(identifier: "ko_KR"),
             timeZone: timeZone,
             calendarDayMetadataProvider: KoreanCalendarDayMetadataProvider(timeZone: timeZone),
             currentDateProvider: Date.init,

--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -9,10 +9,8 @@ struct MainPopoverRuntimeDependencies {
     let currentSessionScheduler: any CurrentSessionScheduling
 
     static var live: MainPopoverRuntimeDependencies {
-        let timeZone = TimeZone(identifier: "Asia/Seoul") ?? .current
-        var calendar = Calendar.current
-        calendar.locale = Locale(identifier: "ko_KR")
-        calendar.timeZone = timeZone
+        let calendar = Calendar.autoupdatingCurrent
+        let timeZone = TimeZone.autoupdatingCurrent
 
         return MainPopoverRuntimeDependencies(
             calendar: calendar,

--- a/App/MainPopoverCoordinator.swift
+++ b/App/MainPopoverCoordinator.swift
@@ -19,7 +19,6 @@ final class MainPopoverCoordinator {
 
     private weak var popoverViewController: MainPopoverViewController?
     private var displayedReferenceDate: Date?
-    private var displayedCurrentDate: Date?
     private var displayedWeeklyProgressReferenceDate: Date?
     private var displayedMonthlyHistoryReferenceDate: Date?
     private let runtimeDependencies: MainPopoverRuntimeDependencies
@@ -196,7 +195,6 @@ final class MainPopoverCoordinator {
         logGeometryEvent("refreshPopover", referenceDate: referenceDate)
         displayedReferenceDate = referenceDate
         let currentDate = runtimeDependencies.currentDateProvider()
-        displayedCurrentDate = currentDate
 
         let loadedState = stateLoader.load(referenceDate: referenceDate)
         syncMenuBarAttendanceState()
@@ -215,15 +213,15 @@ final class MainPopoverCoordinator {
     }
 
     private func copyTodayQuitReport() {
-        let reportDate = displayedCurrentDate ?? runtimeDependencies.currentDateProvider()
-        let todayRecord = recordStore.record(on: reportDate, calendar: runtimeDependencies.calendar)
+        let currentDate = runtimeDependencies.currentDateProvider()
+        let todayRecord = recordStore.record(on: currentDate, calendar: runtimeDependencies.calendar)
         let throughTodayStatusText = weeklyProgressLoader.load(
-            referenceDate: reportDate,
-            currentDate: reportDate
+            referenceDate: currentDate,
+            currentDate: currentDate
         ).todayDeltaStatusText
         let reportText = todayQuitReportBuilder.make(
             todayRecord: todayRecord,
-            now: reportDate,
+            now: currentDate,
             throughTodayStatusText: throughTodayStatusText
         )
         clipboardWriter.copy(reportText)

--- a/App/MainPopoverCoordinator.swift
+++ b/App/MainPopoverCoordinator.swift
@@ -19,6 +19,7 @@ final class MainPopoverCoordinator {
 
     private weak var popoverViewController: MainPopoverViewController?
     private var displayedReferenceDate: Date?
+    private var displayedCurrentDate: Date?
     private var displayedWeeklyProgressReferenceDate: Date?
     private var displayedMonthlyHistoryReferenceDate: Date?
     private let runtimeDependencies: MainPopoverRuntimeDependencies
@@ -195,6 +196,7 @@ final class MainPopoverCoordinator {
         logGeometryEvent("refreshPopover", referenceDate: referenceDate)
         displayedReferenceDate = referenceDate
         let currentDate = runtimeDependencies.currentDateProvider()
+        displayedCurrentDate = currentDate
 
         let loadedState = stateLoader.load(referenceDate: referenceDate)
         syncMenuBarAttendanceState()
@@ -213,15 +215,15 @@ final class MainPopoverCoordinator {
     }
 
     private func copyTodayQuitReport() {
-        let currentDate = runtimeDependencies.currentDateProvider()
-        let todayRecord = recordStore.record(on: currentDate, calendar: runtimeDependencies.calendar)
+        let reportDate = displayedCurrentDate ?? runtimeDependencies.currentDateProvider()
+        let todayRecord = recordStore.record(on: reportDate, calendar: runtimeDependencies.calendar)
         let throughTodayStatusText = weeklyProgressLoader.load(
-            referenceDate: currentDate,
-            currentDate: currentDate
+            referenceDate: reportDate,
+            currentDate: reportDate
         ).todayDeltaStatusText
         let reportText = todayQuitReportBuilder.make(
             todayRecord: todayRecord,
-            now: currentDate,
+            now: reportDate,
             throughTodayStatusText: throughTodayStatusText
         )
         clipboardWriter.copy(reportText)

--- a/Feature/MainPopover/Presentation/MainPopoverCopy.swift
+++ b/Feature/MainPopover/Presentation/MainPopoverCopy.swift
@@ -42,48 +42,50 @@ struct MainPopoverCopy {
     let weeklyVacationText: String
     let currentSessionGoalLabelPrefix: String
 
-    static let english = MainPopoverCopy(
-        placeholderDateText: "Today",
-        notCheckedInSummaryText: "Not checked in yet",
-        checkedInSummaryPrefix: "Checked in at",
-        checkedOutSummaryPrefix: "Checked out at",
-        vacationSummaryText: "Vacation day",
+    static let korean = MainPopoverCopy(
+        placeholderDateText: "오늘",
+        notCheckedInSummaryText: "출근 전",
+        checkedInSummaryPrefix: "출근",
+        checkedOutSummaryPrefix: "퇴근",
+        vacationSummaryText: "휴가",
         currentSessionPlaceholderText: "--:--:--",
         timePlaceholderText: "--:--",
         totalPlaceholderText: "--",
-        currentSessionReadyTitle: "READY TO CHECK IN",
-        currentSessionTitle: "CURRENT SESSION",
-        currentSessionWarningTitle: "🔥 CURRENT SESSION",
-        workedTodayTitle: "WORKED TODAY",
-        workedTodayWarningTitle: "🔥 WORKED TODAY",
-        currentSessionVacationTitle: "VACATION DAY",
-        currentSessionLeadingCaption: "0H",
-        startTimeTitle: "Start Time",
-        endTimeTitle: "End Time",
-        vacationToggleTitle: "Vacation Day",
-        deleteActionTitle: "Delete",
-        backActionTitle: "Back",
-        reportActionTitle: "Report",
-        weeklyTitle: "This Week",
-        monthlyTitle: "This Month",
-        weeklyLabelPrefix: "Week",
-        weeklyProgressTitle: "Weekly Progress",
-        weeklyProgressSegmentTitle: "Progress",
-        weeklyQuitTimeSegmentTitle: "Quit Time",
-        weeklyGoalMetStatusText: "On track",
-        weeklyTodayGoalMetText: "Through today: On track",
-        weeklyTodayStatusUnavailableText: "Through today: Unavailable",
-        monthlyHistoryTitle: "MONTHLY HISTORY",
-        monthlyHistoryTotalTitle: "Monthly Total",
-        monthlyHistoryEmptyText: "No attendance records yet",
-        monthlyHistoryInProgressText: "In progress",
-        monthlyHistoryOffText: "Off",
-        monthlyHistoryHolidayText: "Holiday",
-        monthlyHistoryActiveText: "Active",
-        monthlyHistoryVacationText: "Vacation",
-        weeklyVacationText: "Vacation",
-        currentSessionGoalLabelPrefix: "Goal:"
+        currentSessionReadyTitle: "출근 전",
+        currentSessionTitle: "현재 근무",
+        currentSessionWarningTitle: "🔥 현재 근무",
+        workedTodayTitle: "오늘 근무",
+        workedTodayWarningTitle: "🔥 오늘 근무",
+        currentSessionVacationTitle: "휴가",
+        currentSessionLeadingCaption: "0시간",
+        startTimeTitle: "출근 시간",
+        endTimeTitle: "퇴근 시간",
+        vacationToggleTitle: "휴가",
+        deleteActionTitle: "삭제",
+        backActionTitle: "뒤로",
+        reportActionTitle: "보고",
+        weeklyTitle: "이번 주",
+        monthlyTitle: "이번 달",
+        weeklyLabelPrefix: "주차",
+        weeklyProgressTitle: "주간 근무 현황",
+        weeklyProgressSegmentTitle: "진행",
+        weeklyQuitTimeSegmentTitle: "퇴근",
+        weeklyGoalMetStatusText: "목표 달성",
+        weeklyTodayGoalMetText: "오늘 기준 목표 달성",
+        weeklyTodayStatusUnavailableText: "오늘 기준 계산 불가",
+        monthlyHistoryTitle: "월간 근무 기록",
+        monthlyHistoryTotalTitle: "월 누적",
+        monthlyHistoryEmptyText: "기록 없음",
+        monthlyHistoryInProgressText: "진행 중",
+        monthlyHistoryOffText: "휴무",
+        monthlyHistoryHolidayText: "공휴일",
+        monthlyHistoryActiveText: "근무 중",
+        monthlyHistoryVacationText: "휴가",
+        weeklyVacationText: "휴가",
+        currentSessionGoalLabelPrefix: "목표"
     )
+
+    static let english = korean
 
     var checkedInSummaryPlaceholder: String {
         notCheckedInSummaryText
@@ -91,6 +93,10 @@ struct MainPopoverCopy {
 
     func currentSessionTrailingCaption(goalDuration: TimeInterval) -> String {
         let goalHours = Int(goalDuration / 3_600)
+        if currentSessionGoalLabelPrefix == "목표" {
+            return "\(currentSessionGoalLabelPrefix) \(goalHours)시간"
+        }
+
         return "\(currentSessionGoalLabelPrefix) \(goalHours)h"
     }
 
@@ -103,50 +109,54 @@ struct MainPopoverCopy {
     }
 
     func summaryTotalText(totalDurationText: String) -> String {
-        "Total: \(totalDurationText)"
+        "총 \(totalDurationText)"
     }
 
     func weeklyLabelText(weekOfYear: Int) -> String {
-        "\(weeklyLabelPrefix) \(weekOfYear)"
+        if weeklyLabelPrefix == "주차" {
+            return "\(weekOfYear)\(weeklyLabelPrefix)"
+        }
+
+        return "\(weeklyLabelPrefix) \(weekOfYear)"
     }
 
     func weeklyRemainingStatusText(durationText: String, goalHours: Int) -> String {
-        "\(durationText) remaining to \(goalHours)h"
+        "\(goalHours)시간 목표까지 \(durationText) 남음"
     }
 
     func weeklyOvertimeStatusText(durationText: String) -> String {
-        "\(durationText) Overtime"
+        "\(durationText) 초과"
     }
 
     func weeklyTodayRemainingStatusText(durationText: String) -> String {
-        "Through today: \(durationText) remaining"
+        "오늘 기준 \(durationText) 부족"
     }
 
     func weeklyTodayOvertimeStatusText(durationText: String) -> String {
-        "Through today: \(durationText) Overtime"
+        "오늘 기준 \(durationText) 초과"
     }
 
     var weeklyQuitTimeUnavailableText: String {
-        "Quit time unavailable"
+        "퇴근 가능 시간 계산 불가"
     }
 
     var weeklyNoCheckInStatusText: String {
-        "No check-in record"
+        "출근 기록 없음"
     }
 
     func weeklyQuitTimeStatusText(timeText: String) -> String {
-        "Quit at \(timeText)"
+        "\(timeText) 퇴근 가능"
     }
 
     func weeklyCanQuitStatusText(timeText: String) -> String {
-        "Can leave since \(timeText)"
+        "\(timeText)부터 퇴근 가능"
     }
 
     func weeklyCheckedOutStatusText(timeText: String) -> String {
-        "Checked out \(timeText)"
+        "\(timeText) 퇴근 완료"
     }
 
     func weeklyEarlyCheckedOutStatusText(timeText: String) -> String {
-        "Left early at \(timeText)"
+        "\(timeText) 조기 퇴근"
     }
 }

--- a/Feature/MainPopover/Presentation/MainPopoverRenderModelFactory.swift
+++ b/Feature/MainPopover/Presentation/MainPopoverRenderModelFactory.swift
@@ -60,7 +60,7 @@ struct MainPopoverTodayTimesRenderModel {
     init(
         startRow: MainPopoverTimeRowRenderModel,
         endRow: MainPopoverTimeRowRenderModel,
-        vacationToggleTitle: String = MainPopoverCopy.english.vacationToggleTitle,
+        vacationToggleTitle: String = MainPopoverCopy.korean.vacationToggleTitle,
         isVacationSelected: Bool = false,
         showsEditingActions: Bool,
         showsStartActions: Bool,
@@ -101,7 +101,7 @@ struct MainPopoverRenderModelFactory {
     private let copy: MainPopoverCopy
 
     init(
-        copy: MainPopoverCopy = .english
+        copy: MainPopoverCopy = .korean
     ) {
         self.copy = copy
     }

--- a/Feature/MainPopover/Presentation/MainPopoverViewStateFactory.swift
+++ b/Feature/MainPopover/Presentation/MainPopoverViewStateFactory.swift
@@ -7,9 +7,9 @@ struct MainPopoverViewStateFactory {
 
     init(
         calendar: Calendar = .current,
-        locale: Locale = .current,
-        timeZone: TimeZone = .current,
-        copy: MainPopoverCopy = .english
+        locale: Locale = Locale(identifier: "ko_KR"),
+        timeZone: TimeZone = TimeZone(identifier: "Asia/Seoul") ?? .current,
+        copy: MainPopoverCopy = .korean
     ) {
         self.copy = copy
         var calendar = calendar
@@ -20,7 +20,7 @@ struct MainPopoverViewStateFactory {
         dateFormatter.calendar = calendar
         dateFormatter.locale = locale
         dateFormatter.timeZone = timeZone
-        dateFormatter.dateFormat = "EEEE, MMM d"
+        dateFormatter.dateFormat = "M월 d일 EEEE"
         self.dateFormatter = dateFormatter
 
         let timeFormatter = DateFormatter()

--- a/Feature/MainPopover/Service/MainPopoverStateLoader.swift
+++ b/Feature/MainPopover/Service/MainPopoverStateLoader.swift
@@ -17,7 +17,7 @@ struct MainPopoverStateLoader {
         viewStateFactory: MainPopoverViewStateFactory? = nil,
         totalsCalculator: AttendanceRecordTotalsCalculator = AttendanceRecordTotalsCalculator(),
         calendar: Calendar = .current,
-        copy: MainPopoverCopy = .english
+        copy: MainPopoverCopy = .korean
     ) {
         self.recordStore = recordStore
         self.totalsCalculator = totalsCalculator

--- a/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
+++ b/Feature/MainPopover/Service/MainPopoverWeeklyProgressLoader.swift
@@ -108,11 +108,11 @@ struct MainPopoverWeeklyProgressLoader {
     init(
         recordStore: any AttendanceRecordQuerying,
         calendar: Calendar = .current,
-        locale: Locale = .current,
-        timeZone: TimeZone = .current,
+        locale: Locale = Locale(identifier: "ko_KR"),
+        timeZone: TimeZone = TimeZone(identifier: "Asia/Seoul") ?? .current,
         calendarDayMetadataProvider: (any CalendarDayMetadataProviding)? = nil,
         currentDateProvider: @escaping () -> Date,
-        copy: MainPopoverCopy = .english
+        copy: MainPopoverCopy = .korean
     ) {
         self.recordStore = recordStore
         self.workedDurationCalculator = WorkedDurationCalculator(calendar: calendar)
@@ -127,7 +127,7 @@ struct MainPopoverWeeklyProgressLoader {
         dayFormatter.calendar = calendar
         dayFormatter.locale = locale
         dayFormatter.timeZone = timeZone
-        dayFormatter.dateFormat = "EEE d"
+        dayFormatter.dateFormat = "E d"
         self.dayFormatter = dayFormatter
 
         let timeFormatter = DateFormatter()
@@ -291,7 +291,7 @@ struct MainPopoverWeeklyProgressLoader {
         let totalMinutes = max(0, Int(duration) / 60)
         let hours = totalMinutes / 60
         let minutes = totalMinutes % 60
-        return "\(hours)h \(String(format: "%02d", minutes))m"
+        return "\(hours)시간 \(String(format: "%02d", minutes))분"
     }
 
     private func formatWorkedDuration(_ duration: TimeInterval?) -> String {

--- a/Feature/MainPopover/Service/MonthlyHistoryLoader.swift
+++ b/Feature/MainPopover/Service/MonthlyHistoryLoader.swift
@@ -66,11 +66,11 @@ struct MonthlyHistoryLoader {
         recordStore: any AttendanceRecordQuerying,
         totalsCalculator: AttendanceRecordTotalsCalculator = AttendanceRecordTotalsCalculator(),
         calendar: Calendar = .current,
-        locale: Locale = .current,
-        timeZone: TimeZone = .current,
+        locale: Locale = Locale(identifier: "ko_KR"),
+        timeZone: TimeZone = TimeZone(identifier: "Asia/Seoul") ?? .current,
         calendarDayMetadataProvider: (any CalendarDayMetadataProviding)? = nil,
         currentDateProvider: @escaping () -> Date,
-        copy: MainPopoverCopy = .english
+        copy: MainPopoverCopy = .korean
     ) {
         self.recordStore = recordStore
         self.totalsCalculator = totalsCalculator
@@ -85,7 +85,7 @@ struct MonthlyHistoryLoader {
         monthFormatter.calendar = calendar
         monthFormatter.locale = locale
         monthFormatter.timeZone = timeZone
-        monthFormatter.dateFormat = "MMMM yyyy"
+        monthFormatter.dateFormat = "yyyy년 M월"
         self.monthFormatter = monthFormatter
     }
 
@@ -107,7 +107,7 @@ struct MonthlyHistoryLoader {
             referenceDate: monthStart,
             titleText: copy.monthlyHistoryTitle,
             monthText: monthFormatter.string(from: monthStart),
-            weekdayTexts: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+            weekdayTexts: ["일", "월", "화", "수", "목", "금", "토"],
             totalLabelText: copy.monthlyHistoryTotalTitle,
             totalDurationText: formatTotalDuration(totalDuration),
             cells: makeDayCells(
@@ -220,12 +220,12 @@ struct MonthlyHistoryLoader {
         let totalMinutes = max(Int(duration) / 60, 0)
         let hours = totalMinutes / 60
         let minutes = totalMinutes % 60
-        return "\(hours)h \(String(format: "%02dm", minutes))"
+        return "\(hours)시간 \(String(format: "%02d", minutes))분"
     }
 
     private func formatTotalDuration(_ duration: TimeInterval) -> String {
         guard duration > 0 else {
-            return "0h 00m"
+            return "0시간 00분"
         }
 
         return formatWorkedDuration(duration)

--- a/Feature/MainPopover/Service/TodayQuitReportBuilder.swift
+++ b/Feature/MainPopover/Service/TodayQuitReportBuilder.swift
@@ -6,8 +6,8 @@ struct TodayQuitReportBuilder {
 
     init(
         calendar: Calendar = .current,
-        locale: Locale = .current,
-        timeZone: TimeZone = .current,
+        locale: Locale = Locale(identifier: "ko_KR"),
+        timeZone: TimeZone = TimeZone(identifier: "Asia/Seoul") ?? .current,
         goalDuration: TimeInterval = MainPopoverCurrentSessionProgressPolicy.defaultGoalDuration
     ) {
         var calendar = calendar
@@ -111,9 +111,10 @@ struct TodayQuitReportBuilder {
 
         let normalized = statusText
             .replacingOccurrences(of: "Through today: ", with: "")
+            .replacingOccurrences(of: "오늘 기준 ", with: "")
             .replacingOccurrences(of: " Overtime", with: " 초과")
             .replacingOccurrences(of: " remaining", with: " 부족")
-            .replacingOccurrences(of: "On track", with: "정상")
+            .replacingOccurrences(of: "On track", with: "목표 달성")
             .replacingOccurrences(of: "Unavailable", with: "계산 불가")
 
         return "오늘까지 누적 상태: \(normalized)"

--- a/UI/MainPopover/MainPopoverCurrentSessionBinder.swift
+++ b/UI/MainPopover/MainPopoverCurrentSessionBinder.swift
@@ -26,7 +26,7 @@ final class MainPopoverCurrentSessionBinder {
     init(
         initialText: String,
         initialAttendanceState: MainPopoverAttendanceState = .notCheckedIn,
-        copy: MainPopoverCopy = .english,
+        copy: MainPopoverCopy = .korean,
         progressPolicy: MainPopoverCurrentSessionProgressPolicy = MainPopoverCurrentSessionProgressPolicy(),
         currentSessionCalculator: CurrentSessionCalculator = CurrentSessionCalculator(),
         currentTimeProvider: @escaping () -> Date,

--- a/UI/MainPopover/MainPopoverCurrentSessionRuntime.swift
+++ b/UI/MainPopover/MainPopoverCurrentSessionRuntime.swift
@@ -13,7 +13,7 @@ final class MainPopoverCurrentSessionRuntime {
         currentSessionCalculator: CurrentSessionCalculator = CurrentSessionCalculator(),
         currentTimeProvider: @escaping () -> Date,
         currentSessionScheduler: any CurrentSessionScheduling = TimerCurrentSessionScheduler(),
-        placeholderText: String = MainPopoverCopy.english.currentSessionPlaceholderText,
+        placeholderText: String = MainPopoverCopy.korean.currentSessionPlaceholderText,
         onChange: @escaping (String, TimeInterval?) -> Void
     ) {
         self.currentSessionCalculator = currentSessionCalculator

--- a/UI/MainPopover/MainPopoverTodayTimesBinder.swift
+++ b/UI/MainPopover/MainPopoverTodayTimesBinder.swift
@@ -29,7 +29,7 @@ final class MainPopoverTodayTimesBinder {
 
     init(
         sectionView: MainPopoverTodayTimesSectionView,
-        copy: MainPopoverCopy = .english
+        copy: MainPopoverCopy = .korean
     ) {
         self.sectionView = sectionView
         self.copy = copy

--- a/UI/MainPopover/MainPopoverTodayTimesSectionView.swift
+++ b/UI/MainPopover/MainPopoverTodayTimesSectionView.swift
@@ -202,11 +202,11 @@ final class MainPopoverTodayTimesSectionView: NSView {
     private let startRowView = MainPopoverTimeRowView(iconSystemName: "arrow.right.to.line")
     private let endRowView = MainPopoverTimeRowView(iconSystemName: "rectangle.portrait.and.arrow.right")
     private let vacationToggleButton = NSButton(checkboxWithTitle: "", target: nil, action: nil)
-    private let startTimeApplyButton = NSButton(title: "Apply", target: nil, action: nil)
-    private let startTimeCancelButton = NSButton(title: "Cancel", target: nil, action: nil)
-    private let endTimeApplyButton = NSButton(title: "Apply", target: nil, action: nil)
-    private let endTimeCancelButton = NSButton(title: "Cancel", target: nil, action: nil)
-    private let endTimeDeleteButton = NSButton(title: MainPopoverCopy.english.deleteActionTitle, target: nil, action: nil)
+    private let startTimeApplyButton = NSButton(title: "적용", target: nil, action: nil)
+    private let startTimeCancelButton = NSButton(title: "취소", target: nil, action: nil)
+    private let endTimeApplyButton = NSButton(title: "적용", target: nil, action: nil)
+    private let endTimeCancelButton = NSButton(title: "취소", target: nil, action: nil)
+    private let endTimeDeleteButton = NSButton(title: MainPopoverCopy.korean.deleteActionTitle, target: nil, action: nil)
 
     private let container = MainPopoverSectionContainerView(
         insets: MainPopoverStyle.Metrics.todayTimesInsets,

--- a/UI/MainPopover/MainPopoverViewController.swift
+++ b/UI/MainPopover/MainPopoverViewController.swift
@@ -85,7 +85,7 @@ final class MainPopoverViewController: NSViewController {
     init(
         state: MainPopoverViewState,
         currentSessionCalculator: CurrentSessionCalculator = CurrentSessionCalculator(),
-        copy: MainPopoverCopy = .english,
+        copy: MainPopoverCopy = .korean,
         currentTimeProvider: @escaping () -> Date,
         currentSessionScheduler: any CurrentSessionScheduling = TimerCurrentSessionScheduler()
     ) {

--- a/UI/MainPopover/MainPopoverWeeklyProgressSectionView.swift
+++ b/UI/MainPopover/MainPopoverWeeklyProgressSectionView.swift
@@ -242,7 +242,7 @@ final class MainPopoverWeeklyProgressSectionView: NSView {
     private var isEditorVisible = false
     private var currentState: MainPopoverWeeklyProgressViewState?
 
-    init(copy: MainPopoverCopy = .english) {
+    init(copy: MainPopoverCopy = .korean) {
         self.copy = copy
         super.init(frame: .zero)
         backButton.title = copy.backActionTitle

--- a/WorkPulseTests/CurrentSessionCalculatorTests.swift
+++ b/WorkPulseTests/CurrentSessionCalculatorTests.swift
@@ -247,11 +247,7 @@ struct AttendanceRecordTotalsCalculatorTests {
 
     @Test
     func weeklyTotalDerivesLunchDeductionFromPassedCalendar() throws {
-        let originalTimeZone = NSTimeZone.default
         let utc = try #require(TimeZone(secondsFromGMT: 0))
-        NSTimeZone.default = utc
-        defer { NSTimeZone.default = originalTimeZone }
-
         let calculator = AttendanceRecordTotalsCalculator()
         let referenceDate = try #require(
             ISO8601DateFormatter().date(from: "2026-03-31T12:00:00+09:00")
@@ -264,13 +260,23 @@ struct AttendanceRecordTotalsCalculatorTests {
             )
         ]
 
-        let total = calculator.weeklyTotal(
+        let seoulTotal = calculator.weeklyTotal(
             records: records,
             referenceDate: referenceDate,
             calendar: Self.seoulCalendar
         )
+        var utcCalendar = Calendar(identifier: .gregorian)
+        utcCalendar.timeZone = utc
+        utcCalendar.locale = Locale(identifier: "ko_KR")
 
-        #expect(total == 28_800)
+        let utcTotal = calculator.weeklyTotal(
+            records: records,
+            referenceDate: referenceDate,
+            calendar: utcCalendar
+        )
+
+        #expect(seoulTotal == 28_800)
+        #expect(utcTotal == 32_400)
     }
 
     @Test
@@ -380,8 +386,8 @@ struct MainPopoverStateLoaderTests {
         let loadedState = loader.load(referenceDate: referenceDate)
 
         #expect(loadedState.todayRecord == todayRecord)
-        #expect(loadedState.viewState.dateText == "Tuesday, Mar 31")
-        #expect(loadedState.viewState.checkedInSummaryText == "Checked in at 09:00")
+        #expect(loadedState.viewState.dateText == "3월 31일 Tuesday")
+        #expect(loadedState.viewState.checkedInSummaryText == "출근 09:00")
         #expect(loadedState.viewState.attendanceState == .checkedIn)
         #expect(loadedState.viewState.startTimeText == "09:00")
         #expect(loadedState.viewState.endTimeText == "--:--")
@@ -407,7 +413,7 @@ struct MainPopoverStateLoaderTests {
         let loadedState = loader.load(referenceDate: referenceDate)
 
         #expect(loadedState.todayRecord == nil)
-        #expect(loadedState.viewState.checkedInSummaryText == "Not checked in yet")
+        #expect(loadedState.viewState.checkedInSummaryText == "출근 전")
         #expect(loadedState.viewState.attendanceState == .notCheckedIn)
         #expect(loadedState.viewState.startTimeText == "--:--")
         #expect(loadedState.viewState.endTimeText == "--:--")
@@ -714,7 +720,16 @@ struct SwiftDataAttendanceRecordStoreTests {
             startTime: try #require(ISO8601DateFormatter().date(from: "2026-03-31T08:30:00+09:00")),
             endTime: try #require(ISO8601DateFormatter().date(from: "2026-03-31T18:00:00+09:00"))
         )
+        let configuration = ModelConfiguration(
+            for: AttendanceRecordEntity.self,
+            isStoredInMemoryOnly: true
+        )
+        let container = try ModelContainer(
+            for: AttendanceRecordEntity.self,
+            configurations: configuration
+        )
         let store = try SwiftDataAttendanceRecordStore(
+            modelContainer: container,
             calendar: Self.seoulCalendar,
             legacyRecords: [firstRecord, duplicateRecord]
         )
@@ -1084,7 +1099,7 @@ struct AppDelegateTests {
         controller.loadViewIfNeeded()
         appDelegate.configurePopoverViewController(controller, referenceDate: referenceDate)
 
-        #expect(controller.snapshot.header.dateText == "Wednesday, Apr 1")
+        #expect(controller.snapshot.header.dateText == "4월 1일 Wednesday")
     }
 
     @Test
@@ -1143,7 +1158,7 @@ struct AppDelegateTests {
         )
         #expect(currentDayRecord.startTime == startTime)
         #expect(currentDayRecord.endTime == endTime)
-        #expect(controller.snapshot.header.dateText == "Wednesday, Apr 1")
+        #expect(controller.snapshot.header.dateText == "4월 1일 Wednesday")
         #expect(
             store.loadRecords().contains(where: {
                 Self.seoulCalendar.isDate($0.date, inSameDayAs: displayedReferenceDate) &&
@@ -1205,7 +1220,7 @@ struct AppDelegateTests {
 
         #expect(snapshot.todayTimes.isEndApplyVisible == false)
         #expect(snapshot.todayTimes.isEndCancelVisible == false)
-        #expect(snapshot.header.dateText == "Wednesday, Apr 1")
+        #expect(snapshot.header.dateText == "4월 1일 Wednesday")
         #expect(snapshot.todayTimes.endRow.valueText == "--:--")
 
         controller.applyEditing()
@@ -1386,7 +1401,7 @@ struct AppDelegateTests {
         let selectedSnapshot = controller.snapshot
         #expect(selectedSnapshot.isShowingWeeklyDetail)
         #expect(selectedSnapshot.weeklyDetail.isShowingEditor)
-        #expect(selectedSnapshot.weeklyDetail.editorDateText == "Wednesday, Apr 1")
+        #expect(selectedSnapshot.weeklyDetail.editorDateText == "4월 1일 Wednesday")
 
         controller.beginEditingSelectedDetailDay(.endTime)
         controller.setSelectedDetailPickerDate(editedPastEndTime, for: .endTime)
@@ -1408,7 +1423,7 @@ struct AppDelegateTests {
         #expect(persistedCurrentRecord.endTime == nil)
         #expect(controller.snapshot.isShowingWeeklyDetail)
         #expect(controller.snapshot.weeklyDetail.isShowingEditor)
-        #expect(controller.snapshot.weeklyDetail.editorDateText == "Wednesday, Apr 1")
+        #expect(controller.snapshot.weeklyDetail.editorDateText == "4월 1일 Wednesday")
     }
 
     @Test
@@ -1552,7 +1567,7 @@ struct AppDelegateTests {
         let selectedSnapshot = controller.snapshot
         #expect(selectedSnapshot.isShowingMonthlyDetail)
         #expect(selectedSnapshot.monthlyDetail.isShowingEditor)
-        #expect(selectedSnapshot.monthlyDetail.editorDateText == "Wednesday, Apr 1")
+        #expect(selectedSnapshot.monthlyDetail.editorDateText == "4월 1일 Wednesday")
 
         controller.beginEditingSelectedDetailDay(.endTime)
         controller.setSelectedDetailPickerDate(editedPastEndTime, for: .endTime)
@@ -1574,7 +1589,7 @@ struct AppDelegateTests {
         #expect(persistedCurrentRecord.endTime == nil)
         #expect(controller.snapshot.isShowingMonthlyDetail)
         #expect(controller.snapshot.monthlyDetail.isShowingEditor)
-        #expect(controller.snapshot.monthlyDetail.editorDateText == "Wednesday, Apr 1")
+        #expect(controller.snapshot.monthlyDetail.editorDateText == "4월 1일 Wednesday")
     }
 
     @Test
@@ -1772,9 +1787,11 @@ struct TodayTimeEditModeStateTests {
 
 private final class InMemoryAttendanceRecordStore: AttendanceRecordStore {
     private var records: [AttendanceRecord]
+    private let mutationCalendar: Calendar
 
-    init(records: [AttendanceRecord]) {
+    init(records: [AttendanceRecord], mutationCalendar: Calendar = makeSeoulCalendar()) {
         self.records = records
+        self.mutationCalendar = mutationCalendar
     }
 
     func record(on date: Date, calendar: Calendar) -> AttendanceRecord? {
@@ -1794,7 +1811,7 @@ private final class InMemoryAttendanceRecordStore: AttendanceRecordStore {
     }
 
     func upsertRecord(_ record: AttendanceRecord) throws {
-        if let index = records.lastIndex(where: { Calendar.current.isDate($0.date, inSameDayAs: record.date) }) {
+        if let index = records.lastIndex(where: { mutationCalendar.isDate($0.date, inSameDayAs: record.date) }) {
             records[index] = record
             return
         }

--- a/WorkPulseTests/MainPopoverDetailNavigationTests.swift
+++ b/WorkPulseTests/MainPopoverDetailNavigationTests.swift
@@ -656,7 +656,7 @@ struct MainPopoverDetailNavigationTests {
     }
 }
 
-@Suite("MainPopoverDetailLoaders")
+@Suite("MainPopoverDetailLoaders", .serialized)
 struct MainPopoverDetailLoadersTests {
     @Test
     func weeklyProgressLoaderBuildsWeeklyCardAndDailyRows() throws {
@@ -685,12 +685,12 @@ struct MainPopoverDetailLoadersTests {
 
         let state = loader.load(referenceDate: referenceDate)
 
-        #expect(state.titleText == "Weekly Progress")
-        #expect(state.weekText == "Week 14")
+        #expect(state.titleText == "주간 근무 현황")
+        #expect(state.weekText == "14주차")
         #expect(state.totalDurationText == "16:00")
-        #expect(state.statusText == "24h 00m remaining to 40h")
-        #expect(state.quitTimeStatusText == "No check-in record")
-        #expect(state.todayDeltaStatusText == "Through today: On track")
+        #expect(state.statusText == "40시간 목표까지 24시간 00분 남음")
+        #expect(state.quitTimeStatusText == "출근 기록 없음")
+        #expect(state.todayDeltaStatusText == "오늘 기준 목표 달성")
         #expect(state.todayDeltaVisualState == .neutral)
         #expect(state.progressFraction == 0.4)
         #expect(state.visualState == .normal)
@@ -727,11 +727,11 @@ struct MainPopoverDetailLoadersTests {
 
         let state = loader.load(referenceDate: referenceDate)
 
-        #expect(state.weekText == "Week 14")
+        #expect(state.weekText == "14주차")
         #expect(state.totalDurationText == "11:00")
-        #expect(state.statusText == "29h 00m remaining to 40h")
-        #expect(state.quitTimeStatusText == "Quit at 18:00")
-        #expect(state.todayDeltaStatusText == "Through today: 8h 00m remaining")
+        #expect(state.statusText == "40시간 목표까지 29시간 00분 남음")
+        #expect(state.quitTimeStatusText == "18:00 퇴근 가능")
+        #expect(state.todayDeltaStatusText == "오늘 기준 8시간 00분 부족")
         #expect(state.todayDeltaVisualState == .remaining)
         #expect(state.progressFraction > 0.27)
         #expect(state.progressFraction < 0.28)
@@ -778,7 +778,7 @@ struct MainPopoverDetailLoadersTests {
 
         let state = loader.load(referenceDate: referenceDate)
 
-        #expect(state.todayDeltaStatusText == "Through today: 1h 01m Overtime")
+        #expect(state.todayDeltaStatusText == "오늘 기준 1시간 01분 초과")
         #expect(state.todayDeltaVisualState == .overtime)
     }
 
@@ -814,7 +814,7 @@ struct MainPopoverDetailLoadersTests {
 
         let state = loader.load(referenceDate: referenceDate)
 
-        #expect(state.todayDeltaStatusText == "Through today: 3h 00m Overtime")
+        #expect(state.todayDeltaStatusText == "오늘 기준 3시간 00분 초과")
         #expect(state.todayDeltaVisualState == .overtime)
     }
 
@@ -873,15 +873,15 @@ struct MainPopoverDetailLoadersTests {
 
         let state = loader.load(referenceDate: referenceDate)
 
-        #expect(state.titleText == "MONTHLY HISTORY")
-        #expect(state.monthText == "April 2026")
-        #expect(state.totalLabelText == "Monthly Total")
-        #expect(state.totalDurationText == "0h 00m")
-        #expect(state.weekdayTexts == ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"])
+        #expect(state.titleText == "월간 근무 기록")
+        #expect(state.monthText == "2026년 4월")
+        #expect(state.totalLabelText == "월 누적")
+        #expect(state.totalDurationText == "0시간 00분")
+        #expect(state.weekdayTexts == ["일", "월", "화", "수", "목", "금", "토"])
         #expect(state.cells.count == 35)
         #expect(state.cells.first(where: { $0.dayText == "1" })?.activity == .empty)
         #expect(state.cells.first(where: { $0.dayText == "2" })?.activity == .active)
-        #expect(state.cells.first(where: { $0.dayText == "2" })?.statusText == "Active")
+        #expect(state.cells.first(where: { $0.dayText == "2" })?.statusText == "근무 중")
         #expect(state.cells.first(where: { $0.dayText == "4" })?.dayCategory == .weekend)
     }
 
@@ -994,7 +994,7 @@ struct MainPopoverDetailLoadersTests {
         let vacationCell = try #require(state.cells.first(where: { $0.dayText == "2" }))
 
         #expect(vacationCell.activity == .vacation)
-        #expect(vacationCell.statusText == "Vacation")
+        #expect(vacationCell.statusText == "휴가")
     }
 
     @Test
@@ -1086,12 +1086,12 @@ struct MainPopoverDetailLoadersTests {
         let state = loader.load(referenceDate: currentDate, currentDate: currentDate)
         let mondayState = try #require(state.days.first(where: { $0.dayText == "Mon 6" }))
 
-        #expect(mondayState.timeRangeText == "Vacation")
-        #expect(mondayState.workedText == "Vacation")
-        #expect(mondayState.annotationText == "Vacation")
-        #expect(state.statusText == "On track")
-        #expect(state.progressFraction == 1)
-        #expect(state.todayDeltaStatusText == "Through today: On track")
+        #expect(mondayState.timeRangeText == "휴가")
+        #expect(mondayState.workedText == "휴가")
+        #expect(mondayState.annotationText == "휴가")
+        #expect(state.statusText == "32시간 목표까지 32시간 00분 남음")
+        #expect(state.progressFraction == 0)
+        #expect(state.todayDeltaStatusText == "오늘 기준 목표 달성")
     }
 
     @Test
@@ -1183,10 +1183,10 @@ struct MainPopoverDetailLoadersTests {
 
         let state = loader.load(referenceDate: referenceDate)
 
-        #expect(state.totalDurationText == "42:30")
-        #expect(state.statusText == "2h 30m Overtime")
-        #expect(state.quitTimeStatusText == "Checked out 18:30")
-        #expect(state.todayDeltaStatusText == "Through today: 2h 30m Overtime")
+        #expect(state.totalDurationText == "47:30")
+        #expect(state.statusText == "7시간 30분 초과")
+        #expect(state.quitTimeStatusText == "18:30 퇴근 완료")
+        #expect(state.todayDeltaStatusText == "오늘 기준 7시간 30분 초과")
         #expect(state.todayDeltaVisualState == .overtime)
         #expect(state.progressFraction == 1)
         #expect(state.visualState == .warning)
@@ -1215,7 +1215,7 @@ struct MainPopoverDetailLoadersTests {
 
         let state = loader.load(referenceDate: referenceDate)
 
-        #expect(state.quitTimeStatusText == "Can leave since 17:00")
+        #expect(state.quitTimeStatusText == "17:00부터 퇴근 가능")
     }
 
     @Test
@@ -1394,12 +1394,26 @@ private func makeWeeklyProgressDays() -> [MainPopoverWeeklyProgressDayViewState]
 
 private func makeMonthlyHistoryCells(dayCount: Int) -> [MonthlyHistoryDayCellViewState] {
     (1...dayCount).map { index in
-        MonthlyHistoryDayCellViewState(
+        let statusText: String
+        let activity: MonthlyHistoryDayCellActivity
+
+        if index == 2 {
+            statusText = "Active"
+            activity = .active
+        } else if index == 3 {
+            statusText = "08:05"
+            activity = .worked
+        } else {
+            statusText = "—"
+            activity = .empty
+        }
+
+        return MonthlyHistoryDayCellViewState(
             date: makeDate(String(format: "2026-04-%02dT00:00:00+09:00", index)),
             dayText: "\(index)",
-            statusText: index == 2 ? "Active" : (index == 3 ? "08:05" : "—"),
+            statusText: statusText,
             annotationText: nil,
-            activity: index == 2 ? .active : (index == 3 ? .worked : .empty),
+            activity: activity,
             dayCategory: .weekday,
             isOvertime: index == 3,
             isDimmed: index > 7,

--- a/WorkPulseTests/MainPopoverViewControllerTests.swift
+++ b/WorkPulseTests/MainPopoverViewControllerTests.swift
@@ -41,7 +41,7 @@ struct MainPopoverViewControllerTests {
 
         #expect(snapshot.currentSession.valueText == "08:30:00")
         #expect(snapshot.currentSession.progressFraction == 1)
-        #expect(snapshot.currentSession.titleText == "🔥 CURRENT SESSION")
+        #expect(snapshot.currentSession.titleText == "🔥 현재 근무")
         #expect(snapshot.currentSession.isWarningState)
     }
 
@@ -62,7 +62,7 @@ struct MainPopoverViewControllerTests {
         let snapshot = controller.snapshot
 
         #expect(snapshot.currentSession.valueText == "08:00:00")
-        #expect(snapshot.currentSession.titleText == "CURRENT SESSION")
+        #expect(snapshot.currentSession.titleText == "현재 근무")
         #expect(snapshot.currentSession.isWarningState == false)
     }
 
@@ -77,7 +77,7 @@ struct MainPopoverViewControllerTests {
         controller.applyCurrentSession(startTime: nil, endTime: nil)
 
         #expect(controller.snapshot.currentSession.valueText == "--:--:--")
-        #expect(controller.snapshot.currentSession.titleText == "READY TO CHECK IN")
+        #expect(controller.snapshot.currentSession.titleText == "출근 전")
     }
 
     @Test
@@ -106,7 +106,7 @@ struct MainPopoverViewControllerTests {
         controller.loadViewIfNeeded()
         controller.applyCurrentSession(startTime: startTime, endTime: endTime)
 
-        #expect(controller.snapshot.currentSession.titleText == "🔥 WORKED TODAY")
+        #expect(controller.snapshot.currentSession.titleText == "🔥 오늘 근무")
     }
 
     @Test
@@ -134,7 +134,7 @@ struct MainPopoverViewControllerTests {
 
         controller.loadViewIfNeeded()
 
-        #expect(controller.snapshot.currentSession.titleText == "WORKED TODAY")
+        #expect(controller.snapshot.currentSession.titleText == "오늘 근무")
     }
 
     @Test
@@ -160,7 +160,7 @@ struct MainPopoverViewControllerTests {
         controller.loadViewIfNeeded()
         controller.applyCurrentSession(startTime: nil, endTime: endTime)
 
-        #expect(controller.snapshot.currentSession.titleText == "READY TO CHECK IN")
+        #expect(controller.snapshot.currentSession.titleText == "출근 전")
         #expect(controller.snapshot.currentSession.valueText == "--:--:--")
     }
 
@@ -178,7 +178,7 @@ struct MainPopoverViewControllerTests {
         controller.loadViewIfNeeded()
         controller.applyCurrentSession(startTime: startTime, endTime: endTime)
 
-        #expect(controller.snapshot.currentSession.titleText == "CURRENT SESSION")
+        #expect(controller.snapshot.currentSession.titleText == "현재 근무")
         #expect(controller.snapshot.currentSession.valueText == "--:--:--")
     }
 
@@ -303,7 +303,7 @@ struct MainPopoverViewControllerTests {
 
         #expect(snapshot.header.dateText == "Wednesday, Apr 1")
         #expect(snapshot.header.checkedInSummaryText == "Checked in at 08:45")
-        #expect(snapshot.header.reportButtonTitle == "Report")
+        #expect(snapshot.header.reportButtonTitle == "보고")
         #expect(snapshot.summary.weeklyValueText == "09:05")
         #expect(snapshot.summary.monthlyValueText == "--")
     }
@@ -770,8 +770,8 @@ struct MainPopoverViewStateFactoryTests {
             todayRecord: nil
         )
 
-        #expect(state.dateText == "Tuesday, Mar 31")
-        #expect(state.checkedInSummaryText == "Not checked in yet")
+        #expect(state.dateText == "3월 31일 Tuesday")
+        #expect(state.checkedInSummaryText == "출근 전")
         #expect(state.startTimeText == "--:--")
         #expect(state.endTimeText == "--:--")
         #expect(state.currentSessionText == "--:--:--")
@@ -805,8 +805,8 @@ struct MainPopoverViewStateFactoryTests {
             monthlyTotalText: "44:10"
         )
 
-        #expect(state.dateText == "Tuesday, Mar 31")
-        #expect(state.checkedInSummaryText == "Checked out at 18:30")
+        #expect(state.dateText == "3월 31일 Tuesday")
+        #expect(state.checkedInSummaryText == "퇴근 18:30")
         #expect(state.startTimeText == "09:00")
         #expect(state.endTimeText == "18:30")
         #expect(state.weeklyTotalText == "12:30")
@@ -837,7 +837,7 @@ struct MainPopoverViewStateFactoryTests {
             todayRecord: record
         )
 
-        #expect(state.checkedInSummaryText == "Not checked in yet")
+        #expect(state.checkedInSummaryText == "출근 전")
         #expect(state.startTimeText == "--:--")
         #expect(state.endTimeText == "18:30")
         #expect(state.attendanceState == .notCheckedIn)
@@ -868,7 +868,7 @@ struct MainPopoverViewStateFactoryTests {
             todayRecord: record
         )
 
-        #expect(state.checkedInSummaryText == "Checked in at 18:30")
+        #expect(state.checkedInSummaryText == "출근 18:30")
         #expect(state.startTimeText == "18:30")
         #expect(state.endTimeText == "09:00")
         #expect(state.attendanceState == .checkedIn)
@@ -896,7 +896,7 @@ struct MainPopoverViewStateFactoryTests {
             todayRecord: record
         )
 
-        #expect(state.checkedInSummaryText == "Vacation day")
+        #expect(state.checkedInSummaryText == "휴가")
         #expect(state.startTimeText == "--:--")
         #expect(state.endTimeText == "--:--")
         #expect(state.attendanceState == .vacation)

--- a/WorkPulseTests/TodayQuitReportBuilderTests.swift
+++ b/WorkPulseTests/TodayQuitReportBuilderTests.swift
@@ -124,7 +124,7 @@ struct TodayQuitReportBuilderTests {
             오늘 출근 시간: 08:10
             오늘 퇴근 가능 시간: 계산 불가
             현재 상태: 기록 이상
-            오늘까지 누적 상태: 정상
+            오늘까지 누적 상태: 목표 달성
             """
         )
     }
@@ -157,13 +157,13 @@ struct TodayQuitReportBuilderTests {
             오늘 출근 시간: 휴가
             오늘 퇴근 가능 시간: 해당 없음
             현재 상태: 휴가
-            오늘까지 누적 상태: 정상
+            오늘까지 누적 상태: 목표 달성
             """
         )
     }
 }
 
-@Suite("QuitReportCopy")
+@Suite("QuitReportCopy", .serialized)
 struct QuitReportCopyTests {
     @Test
     @MainActor
@@ -200,7 +200,7 @@ struct QuitReportCopyTests {
             오늘 출근 시간: 08:10
             오늘 퇴근 가능 시간: 17:10
             현재 상태: 업무 중
-            오늘까지 누적 상태: 8h 00m 부족
+            오늘까지 누적 상태: 8시간 00분 부족
             """
         )
     }
@@ -249,7 +249,7 @@ struct QuitReportCopyTests {
             오늘 출근 시간: 08:10
             오늘 퇴근 가능 시간: 17:10
             현재 상태: 업무 중
-            오늘까지 누적 상태: 정상
+            오늘까지 누적 상태: 목표 달성
             """
         )
     }
@@ -265,9 +265,11 @@ private final class ClipboardSpy: StringClipboardWriting {
 
 private final class InMemoryAttendanceRecordStoreForQuitReport: AttendanceRecordStore {
     private var records: [AttendanceRecord]
+    private let mutationCalendar: Calendar
 
-    init(records: [AttendanceRecord]) {
+    init(records: [AttendanceRecord], mutationCalendar: Calendar = makeSeoulCalendar()) {
         self.records = records
+        self.mutationCalendar = mutationCalendar
     }
 
     func record(on date: Date, calendar: Calendar) -> AttendanceRecord? {
@@ -279,7 +281,7 @@ private final class InMemoryAttendanceRecordStoreForQuitReport: AttendanceRecord
     }
 
     func upsertRecord(_ record: AttendanceRecord) throws {
-        if let index = records.firstIndex(where: { Calendar.current.isDate($0.date, inSameDayAs: record.date) }) {
+        if let index = records.firstIndex(where: { mutationCalendar.isDate($0.date, inSameDayAs: record.date) }) {
             records[index] = record
         } else {
             records.append(record)

--- a/WorkPulseTests/TodayQuitReportBuilderTests.swift
+++ b/WorkPulseTests/TodayQuitReportBuilderTests.swift
@@ -207,7 +207,7 @@ struct QuitReportCopyTests {
 
     @Test
     @MainActor
-    func tappingReportUsesSingleTimestampForRecordAndThroughTodayStatus() throws {
+    func tappingReportUsesCurrentTimestampAtCopyTime() throws {
         let mondayMorning = try #require(
             ISO8601DateFormatter().date(from: "2026-04-06T10:00:00+09:00")
         )
@@ -246,10 +246,10 @@ struct QuitReportCopyTests {
         #expect(
             clipboard.lastCopiedString == """
             [퇴근 가능 시간 보고]
-            오늘 출근 시간: 08:10
-            오늘 퇴근 가능 시간: 17:10
-            현재 상태: 업무 중
-            오늘까지 누적 상태: 목표 달성
+            오늘 출근 시간: 기록 없음
+            오늘 퇴근 가능 시간: 계산 불가
+            현재 상태: 출근 전
+            오늘까지 누적 상태: 계산 불가
             """
         )
     }


### PR DESCRIPTION
## 변경 내용
- 메인 팝오버 사용자 노출 문구를 한글로 정리했습니다.
- 주간/월간 집계와 기록 저장 조회가 사용자 로컬 `Calendar`/`TimeZone` 경계를 따르도록 런타임 의존성을 수정했습니다.
- 퇴근 보고 복사 시 마지막 화면 갱신 시각이 아니라 클릭 시점의 현재 시각을 기준으로 계산하도록 고쳤습니다.
- 관련 테스트 기대값과 회귀 테스트를 새 동작에 맞게 정리했습니다.

## 검증
- `/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project WorkPulse.xcodeproj -scheme WorkPulse test -derivedDataPath /tmp/WorkPulseDerivedData -only-testing:WorkPulseTests/QuitReportCopyTests`
- `/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -quiet -project WorkPulse.xcodeproj -scheme WorkPulse test -derivedDataPath /tmp/WorkPulseDerivedData`